### PR TITLE
Disable simd-accel for windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -154,7 +154,7 @@ fn write_tables() {
 #[cfg(all(
     feature = "simd-accel",
     any(target_arch = "x86_64", target_arch = "aarch64"),
-    not(any(target_os = "android", target_os = "ios"))
+    not(any(target_os = "android", target_os = "ios", target_os = "windows"))
 ))]
 fn compile_simd_c() {
     cc::Build::new()
@@ -168,7 +168,7 @@ fn compile_simd_c() {
 #[cfg(not(all(
     feature = "simd-accel",
     any(target_arch = "x86_64", target_arch = "aarch64"),
-    not(any(target_os = "android", target_os = "ios"))
+    not(any(target_os = "android", target_os = "ios", target_os = "windows"))
 )))]
 fn compile_simd_c() {}
 


### PR DESCRIPTION
The simd-accel feature currently fails to build on Windows.  Until somebody wants to fix this properly, let's follow the path of android and ios and ensure simd-accel does nothing on windows.

eg:
```
  process didn't exit successfully: `C:\msys64\home\mvines\solana\target\debug\build\reed-solomon-erasure-61e557d7bc126d5c\build-script-build` (exit code: 1)
--- stdout
TARGET = Some("x86_64-pc-windows-msvc")
HOST = Some("x86_64-pc-windows-msvc")
CC_x86_64-pc-windows-msvc = None
CC_x86_64_pc_windows_msvc = None
HOST_CC = None
CC = None
CFLAGS_x86_64-pc-windows-msvc = None
CFLAGS_x86_64_pc_windows_msvc = None
HOST_CFLAGS = None
CFLAGS = None
CRATE_CC_NO_DEFAULTS = None
CARGO_CFG_TARGET_FEATURE = Some("fxsr,sse,sse2")
DEBUG = Some("true")
running: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.21.27702\\bin\\HostX64\\x64\\cl.exe" "-nologo" "-MD" "-O2" "-Z7" "-Brepro" "-W4" "-march=native" "-std=c11" "-FoC:\\msys64\\home\\mvines\\solana\\target\\debug\\build\\reed-solomon-erasure-2412293776b1fcee\\out\\simd_c\\reedsolomon.o" "-c" "simd_c/reedsolomon.c"
cargo:warning=cl : Command line warning D9002 : ignoring unknown option '-march=native'
cargo:warning=cl : Command line warning D9002 : ignoring unknown option '-std=c11'
reedsolomon.c
C:\Users\mvines\.cargo\registry\src\github.com-1ecc6299db9ec823\reed-solomon-erasure-4.0.0\simd_c\reedsolomon.h(24): fatal error C1083: Cannot open include file: 'unistd.h': No such file or directory
exit code: 2
```