### PR TITLE
Disable simd-accel for MSVC

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -154,6 +154,7 @@ fn write_tables() {
 #[cfg(all(
     feature = "simd-accel",
     any(target_arch = "x86_64", target_arch = "aarch64"),
+    not(target_env = "msvc"),
     not(any(target_os = "android", target_os = "ios"))
 ))]
 fn compile_simd_c() {
@@ -168,6 +169,7 @@ fn compile_simd_c() {
 #[cfg(not(all(
     feature = "simd-accel",
     any(target_arch = "x86_64", target_arch = "aarch64"),
+    not(target_env = "msvc"),
     not(any(target_os = "android", target_os = "ios"))
 )))]
 fn compile_simd_c() {}

--- a/src/galois_8.rs
+++ b/src/galois_8.rs
@@ -117,6 +117,7 @@ macro_rules! return_if_empty {
 #[cfg(not(all(
     feature = "simd-accel",
     any(target_arch = "x86_64", target_arch = "aarch64"),
+    not(target_env = "msvc"),
     not(any(target_os = "android", target_os = "ios"))
 )))]
 pub fn mul_slice(c: u8, input: &[u8], out: &mut [u8]) {
@@ -126,6 +127,7 @@ pub fn mul_slice(c: u8, input: &[u8], out: &mut [u8]) {
 #[cfg(not(all(
     feature = "simd-accel",
     any(target_arch = "x86_64", target_arch = "aarch64"),
+    not(target_env = "msvc"),
     not(any(target_os = "android", target_os = "ios"))
 )))]
 pub fn mul_slice_xor(c: u8, input: &[u8], out: &mut [u8]) {
@@ -259,6 +261,7 @@ fn slice_xor(input: &[u8], out: &mut [u8]) {
 #[cfg(all(
     feature = "simd-accel",
     any(target_arch = "x86_64", target_arch = "aarch64"),
+    not(target_env = "msvc"),
     not(any(target_os = "android", target_os = "ios"))
 ))]
 extern "C" {
@@ -282,6 +285,7 @@ extern "C" {
 #[cfg(all(
     feature = "simd-accel",
     any(target_arch = "x86_64", target_arch = "aarch64"),
+    not(target_env = "msvc"),
     not(any(target_os = "android", target_os = "ios"))
 ))]
 pub fn mul_slice(c: u8, input: &[u8], out: &mut [u8]) {
@@ -303,6 +307,7 @@ pub fn mul_slice(c: u8, input: &[u8], out: &mut [u8]) {
 #[cfg(all(
     feature = "simd-accel",
     any(target_arch = "x86_64", target_arch = "aarch64"),
+    not(target_env = "msvc"),
     not(any(target_os = "android", target_os = "ios"))
 ))]
 pub fn mul_slice_xor(c: u8, input: &[u8], out: &mut [u8]) {


### PR DESCRIPTION
Hey @darrenldl, I'm back with another round of #63 :)

windows-gnu builds fine, but windows-msvc fails due to various reasons:
1.  Command-line args that `cl.exe` can't handle: https://github.com/darrenldl/reed-solomon-erasure/blob/b68f9f34ee94c9060dedeefdd0433712c0f53e57/build.rs#L162-L163
2. `restrict` keyword (cl wants `__restrict`): https://github.com/darrenldl/reed-solomon-erasure/blob/b68f9f34ee94c9060dedeefdd0433712c0f53e57/simd_c/reedsolomon.h#L34-L35
3. GNU vector extensions that need a MSVC equivalent: https://github.com/darrenldl/reed-solomon-erasure/blob/b68f9f34ee94c9060dedeefdd0433712c0f53e57/simd_c/reedsolomon.c#L128-L129

This bites us because cargo doesn't support target-specific features so it's not just a simple matter of disabling the `simd-accel` feature before building the reed-solomon-erasure crate as that would affect the Linux/macOS targets where we certainly do want simd enabled