### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ fn main () {
 
     // Make a copy and transform it into option shards arrangement
     // for feeding into reconstruct_shards
-    let mut shards: Vec<_> = master_copy.clone().into_iter().map(Some).collect();
+    let mut shards: Vec<_> = master_copy.iter().cloned().map(Some).collect();
 
     // We can remove up to 2 shards, which may be data or parity shards
     shards[0] = None;

--- a/src/core.rs
+++ b/src/core.rs
@@ -699,7 +699,7 @@ impl<F: Field> ReedSolomon<F> {
                 // matrix could be used to generate the shards that we have
                 // from the original data.
                 let mut sub_matrix = Matrix::new(self.data_shard_count, self.data_shard_count);
-                for (sub_matrix_row, &valid_index) in valid_indices.into_iter().enumerate() {
+                for (sub_matrix_row, &valid_index) in valid_indices.iter().enumerate() {
                     for c in 0..self.data_shard_count {
                         sub_matrix.set(sub_matrix_row, c, self.matrix.get(valid_index, c));
                     }
@@ -791,7 +791,7 @@ impl<F: Field> ReedSolomon<F> {
         let mut invalid_indices: SmallVec<[usize; 32]> = SmallVec::with_capacity(data_shard_count);
 
         // Separate the shards into groups
-        for (matrix_row, shard) in shards.into_iter().enumerate() {
+        for (matrix_row, shard) in shards.iter_mut().enumerate() {
             // get or initialize the shard so we can reconstruct in-place,
             // but if we are only reconstructing data shard,
             // do not initialize if the shard is not a data shard

--- a/src/galois_8.rs
+++ b/src/galois_8.rs
@@ -550,7 +550,7 @@ mod tests {
     #[test]
     fn test_slice_add() {
         let length_list = [16, 32, 34];
-        for len in length_list.into_iter() {
+        for len in length_list.iter() {
             let mut input = vec![0; *len];
             fill_random(&mut input);
             let mut output = vec![0; *len];

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -17,8 +17,8 @@ macro_rules! acc {
 
 pub fn flatten<T>(m: Vec<Vec<T>>) -> Vec<T> {
     let mut result: Vec<T> = Vec::with_capacity(m.len() * m[0].len());
-    for row in m.into_iter() {
-        for v in row.into_iter() {
+    for row in m {
+        for v in row {
             result.push(v);
         }
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -56,7 +56,7 @@ fn shards_to_option_shards<T: Clone>(shards: &[Vec<T>]) -> Vec<Option<Vec<T>>> {
 fn shards_into_option_shards<T>(shards: Vec<Vec<T>>) -> Vec<Option<Vec<T>>> {
     let mut result = Vec::with_capacity(shards.len());
 
-    for v in shards.into_iter() {
+    for v in shards {
         result.push(Some(v));
     }
     result
@@ -79,7 +79,7 @@ fn option_shards_to_shards<T: Clone>(shards: &[Option<Vec<T>>]) -> Vec<Vec<T>> {
 fn option_shards_into_shards<T>(shards: Vec<Option<Vec<T>>>) -> Vec<Vec<T>> {
     let mut result = Vec::with_capacity(shards.len());
 
-    for shard in shards.into_iter() {
+    for shard in shards {
         let shard = match shard {
             Some(x) => x,
             None => panic!("Missing shard"),


### PR DESCRIPTION
o/

Use `slice::iter` instead of `into_iter` to avoid future breakage

`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.