### PR TITLE
`no_std` support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ branches:
 
 script:
   - cargo build --verbose --all
-  - cargo test  --verbose --all --features=simd-accel
+  # Test `no_std` variant
+  - cargo test --verbose --all --no-default-features
+  # Test `std` variant with SIMD
+  - cargo test --verbose --all --features=simd-accel
 
 env:
   global:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,8 @@ categories= ["encoding"]
 license = "MIT"
 
 [features]
-default = [] # simd off by default
+default = ["std"] # simd off by default
+std = ["parking_lot"]
 simd-accel = ["cc", "libc"]
 
 [badges]
@@ -34,8 +35,14 @@ codecov = { repository = "darrenldl/reed-solomon-erasure" }
 coveralls = { repository = "darrenldl/reed-solomon-erasure" }
 
 [dependencies]
-smallvec = "1.2"
 libc = { version = "0.2", optional = true }
+# `log2()` impl for `no_std`
+libm = "0.2.1"
+# Efficient `Mutex` implementation for `std` environment
+parking_lot = { version = "0.11.2", optional = true }
+smallvec = "1.2"
+# `Mutex` implementation for `no_std` environment with the same high-level API as `parking_lot`
+spin = { version = "0.9.2", default-features = false, features = ["spin_mutex"] }
 
 [dev-dependencies]
 rand = "0.7.2"

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ Many thanks to [@sakridge](https://github.com/sakridge) for adding support for A
 #### build.rs improvements
 Many thanks to [@ryoqun](https://github.com/ryoqun) for improving the usability of the library in the context of cross-compilation (see [PR #75](https://github.com/darrenldl/reed-solomon-erasure/pull/75))
 
+#### no_std support
+Many thanks to Nazar Mokrynskyi [@nazar-pc](https://github.com/nazar-pc) for adding `no_std` support (see [PR #90](https://github.com/darrenldl/reed-solomon-erasure/pull/90))
+
 #### Testers
 Many thanks to the following people for testing and benchmarking on various platforms
 

--- a/build.rs
+++ b/build.rs
@@ -168,7 +168,7 @@ fn compile_simd_c() {
                     flag = &flag["-C".len()..];
                 }
                 if flag.starts_with("target-cpu=") {
-                    return flag["target-cpu=".len()..].to_owned()
+                    return flag["target-cpu=".len()..].to_owned();
                 }
             }
         }

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,4 +1,8 @@
-use std::sync::Arc;
+extern crate alloc;
+
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
 
 use smallvec::SmallVec;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,4 @@
-use std;
-use std::fmt::Formatter;
+use core::fmt::Formatter;
 
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub enum Error {
@@ -38,12 +37,13 @@ impl Error {
     }
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), core::fmt::Error> {
         write!(f, "{}", self.to_string())
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for Error {
     fn description(&self) -> &str {
         self.to_string()
@@ -67,12 +67,13 @@ impl SBSError {
     }
 }
 
-impl std::fmt::Display for SBSError {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
+impl core::fmt::Display for SBSError {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), core::fmt::Error> {
         write!(f, "{}", self.to_string())
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for SBSError {
     fn description(&self) -> &str {
         self.to_string()
@@ -143,11 +144,13 @@ mod tests {
         assert_eq!(SBSError::LeftoverShards.to_string(), "Leftover shards");
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_error_display_does_not_panic() {
         println!("{}", Error::TooFewShards);
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_sbserror_display_does_not_panic() {
         println!("{}", SBSError::TooManyCalls);

--- a/src/galois_16.rs
+++ b/src/galois_16.rs
@@ -4,7 +4,7 @@
 //! field of `GF(2^8)`, as defined in the `galois_8` module.
 
 use crate::galois_8;
-use std::ops::{Add, Div, Mul, Sub};
+use core::ops::{Add, Div, Mul, Sub};
 
 // the irreducible polynomial used as a modulus for the field.
 // print R.irreducible_element(2,algorithm="first_lexicographic" )

--- a/src/galois_8.rs
+++ b/src/galois_8.rs
@@ -328,6 +328,10 @@ pub fn mul_slice_xor(c: u8, input: &[u8], out: &mut [u8]) {
 
 #[cfg(test)]
 mod tests {
+    extern crate alloc;
+
+    use alloc::vec;
+
     use super::*;
     use crate::tests::fill_random;
     use rand;

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,4 +1,9 @@
 #![allow(dead_code)]
+extern crate alloc;
+
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::Field;
 use smallvec::SmallVec;
 
@@ -273,6 +278,10 @@ impl<F: Field> Matrix<F> {
 
 #[cfg(test)]
 mod tests {
+    extern crate alloc;
+
+    use alloc::vec;
+
     use super::Matrix;
     use crate::galois_8;
 

--- a/src/tests/galois_16.rs
+++ b/src/tests/galois_16.rs
@@ -1,3 +1,8 @@
+extern crate alloc;
+
+use alloc::vec;
+use alloc::vec::Vec;
+
 use super::{fill_random, option_shards_into_shards, shards_into_option_shards};
 use crate::galois_16::ReedSolomon;
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,10 @@
 #![allow(dead_code)]
 
+extern crate alloc;
+
+use alloc::vec;
+use alloc::vec::Vec;
+
 use super::{galois_8, Error, SBSError};
 use rand::{self, thread_rng, Rng};
 


### PR DESCRIPTION
In order to switch enable `no_std` support I had to use `libm` for `f32::log2()` impl and use `spin` library for `Mutex` impl (and switched to `parking_lot::Mutex` in `std` since it is generally better than `std` and happens to have the same high-level API as `spin`, so less conditional code).

Mostly mechanical changes otherwise, CI was adjusted to run `no_std` tests.

Fixes #36