### PR TITLE
Performance refactor of v6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "reed-solomon-erasure"
-version = "6.0.0"
+version = "6.1.0"
 authors = ["Darren Ldl <darrenldldev@gmail.com>"]
-edition = "2018"
+edition = "2024"
 build = "build.rs"
 exclude = [
     "appveyor.yml",
@@ -37,23 +37,23 @@ coveralls = { repository = "darrenldl/reed-solomon-erasure" }
 [dependencies]
 libc = { version = "0.2", optional = true }
 # `log2()` impl for `no_std`
-libm = "0.2.1"
-lru = "0.7.8"
+libm = "0.2.15"
+lru = "0.16"
 # Efficient `Mutex` implementation for `std` environment
-parking_lot = { version = "0.11.2", optional = true }
-smallvec = "1.2"
+parking_lot = { version = "0.12", optional = true }
+smallvec = { version = "1.15", features = [ "union" ]}
 # `Mutex` implementation for `no_std` environment with the same high-level API as `parking_lot`
-spin = { version = "0.9.2", default-features = false, features = ["spin_mutex"] }
+spin = { version = "0.10", default-features = false, features = ["spin_mutex"] }
 
 [dev-dependencies]
-rand = { version = "0.7.2", features = ["small_rng"] }
-quickcheck = "0.9"
+rand = { version = "0.9.2", features = ["small_rng"] }
+quickcheck = "1"
 
 # Scientific benchmarking
-criterion = { version = "0.4.0", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 
 [build-dependencies]
-cc = { version = "1.0", optional = true }
+cc = { version = "1.2", optional = true }
 
 [[bench]]
 name = "bandwidth"

--- a/benches/bandwidth.rs
+++ b/benches/bandwidth.rs
@@ -1,33 +1,30 @@
 use std::convert::TryInto;
 
 use criterion::measurement::WallTime;
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkGroup, Criterion};
-use rand::distributions::{Distribution, Standard};
-use rand::rngs::SmallRng;
+use criterion::{BenchmarkGroup, Criterion, criterion_group, criterion_main};
 use rand::SeedableRng;
+use rand::distr::{Distribution, StandardUniform};
+use rand::rngs::SmallRng;
 use reed_solomon_erasure::galois_8::ReedSolomon;
+use std::hint::black_box;
 
 type Shards = Vec<Vec<u8>>;
 
 fn create_shards(block_size: usize, data: usize, parity: usize) -> Shards {
-    let mut small_rng = SmallRng::from_entropy();
+    let mut rng = SmallRng::from_rng(&mut rand::rng());
 
     let mut shards = Vec::new();
 
     // Create data shards with random data
     shards.resize_with(data, || {
-        Standard
-            .sample_iter(&mut small_rng)
+        StandardUniform
+            .sample_iter(&mut rng)
             .take(block_size)
             .collect()
     });
 
     // Create empty parity shards
-    shards.resize_with(data + parity, || {
-        let mut vec = Vec::with_capacity(block_size);
-        vec.resize(block_size, 0);
-        vec
-    });
+    shards.resize(data + parity, vec![0; block_size]);
 
     shards
 }
@@ -189,5 +186,11 @@ fn reconstruct_none(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, encode, reconstruct_one, reconstruct_all, reconstruct_none);
+criterion_group!(
+    benches,
+    encode,
+    reconstruct_one,
+    reconstruct_all,
+    reconstruct_none
+);
 criterion_main!(benches);

--- a/src/core.rs
+++ b/src/core.rs
@@ -721,8 +721,8 @@ impl<F: Field> ReedSolomon<F> {
     /// coefficient rows that encode available and missing shards respectively. Lastly, the returned
     /// reconstruction coefficients are calculated as $C = G_m \cdot G_v^{-1}$.
     ///
-    /// G is stored in the cache at the key `valid_indices`. This key is sufficient because it implies
-    /// the other dimension of $G$, that is `missing_indices`.
+    /// G is stored in the cache at the key `missing_indices`. This key is sufficient because it implies
+    /// the other dimension of $C$, that is `valid_indices`.
     fn get_decode_matrix(
         &self,
         valid_indices: &[usize],
@@ -730,7 +730,7 @@ impl<F: Field> ReedSolomon<F> {
     ) -> Arc<Matrix<F>> {
         {
             let mut cache = self.decode_matrix_cache.lock();
-            if let Some(entry) = cache.get(valid_indices) {
+            if let Some(entry) = cache.get(missing_indices) {
                 return entry.clone();
             }
         }
@@ -754,7 +754,7 @@ impl<F: Field> ReedSolomon<F> {
         {
             let decode_coeffs = decode_coeffs.clone();
             let mut cache = self.decode_matrix_cache.lock();
-            cache.put(Vec::from(valid_indices), decode_coeffs);
+            cache.put(Vec::from(missing_indices), decode_coeffs);
         }
         decode_coeffs
     }
@@ -808,7 +808,7 @@ impl<F: Field> ReedSolomon<F> {
         // Also, create an array of indices of the valid rows we do have
         // and the missing rows.
         //
-        // The valid indices are used to construct the data decode matrix,
+        // The missing indices are used to construct the data decode matrix,
         // and as key in the data decode matrix cache.
         //
         // We need exactly N valid indices, where N = `data_shard_count`,

--- a/src/core.rs
+++ b/src/core.rs
@@ -492,9 +492,9 @@ impl<F: Field> ReedSolomon<F> {
             let inp0 = inputs[0].as_ref();
             F::mul_slice(coeff0, inp0, out);
 
-            // Sum up further codes on the same row `i`. Note that `j` is 0-based.
-            for (j, inp) in inputs[1..].iter().enumerate() {
-                let coeff = matrix_rows[i][j + 1];
+            // Sum up further codes on the same row `i`.
+            for (j, inp) in (1..).zip(inputs[1..].iter()) {
+                let coeff = matrix_rows[i][j];
                 let inp = inp.as_ref();
                 F::mul_slice_add(coeff, inp, out);
             }
@@ -716,13 +716,13 @@ impl<F: Field> ReedSolomon<F> {
     /// Returns an `self.data_shard_count` by `self.parity_shard_count` matrix with multiplicative
     /// coefficients to decode the missing rows.
     ///
-    /// The function computes the generator matrix $G = [I; E]$ where $E$ is the encode coefficients and $I$
-    /// is the identity matrix of the suitable size. Then, it splits $G$ row-wise into $G_v$ and $G_m$ - the
-    /// coefficient rows that encode available and missing shards respectively. Lastly, the returned
-    /// reconstruction coefficients are calculated as $C = G_m \cdot G_v^{-1}$.
+    /// The function splits the systematic generator matrix $G = [I; E]$ (where $E$ is the encode
+    /// coefficient matrix and $I$ is the identity matrix of suitable size) row-wise into $G_v$ and
+    /// $G_m$ - the coefficient rows that encode available and missing shards respectively. It
+    /// returns the the reconstruction coefficients as $C = G_m \cdot G_v^{-1}$.
     ///
-    /// G is stored in the cache at the key `missing_indices`. This key is sufficient because it implies
-    /// the other dimension of $C$, that is `valid_indices`.
+    /// $C$ is stored in the cache at the key `missing_indices`. This key is sufficient because it
+    /// implies the other dimension of $C$, that is `valid_indices`.
     fn get_decode_matrix(
         &self,
         valid_indices: &[usize],

--- a/src/core.rs
+++ b/src/core.rs
@@ -830,7 +830,13 @@ impl<F: Field> ReedSolomon<F> {
             SmallVec::with_capacity(self.parity_shard_count);
 
         for (shard_idx, shard) in shards.iter_mut().enumerate() {
-            match shard.get_or_initialize(shard_len) {
+            let shard_data = if data_only && shard_idx >= self.data_shard_count {
+                shard.get().ok_or(None)
+            } else {
+                shard.get_or_initialize(shard_len).map_err(Some)
+            };
+
+            match shard_data {
                 Ok(shard) => {
                     if valid_shards.len() < self.data_shard_count {
                         valid_shards.push(shard);
@@ -839,12 +845,13 @@ impl<F: Field> ReedSolomon<F> {
                         missing_indices.push(shard_idx);
                     }
                 }
-                Err(Err(_)) => {
+                Err(None) => {
                     // the shard data is not meant to be initialized here,
                     // but we should still note it missing.
                     missing_indices.push(shard_idx);
                 }
-                Err(Ok(shard)) => {
+                Err(Some(x)) => {
+                    let shard = x?;
                     if !data_only || shard_idx < self.data_shard_count {
                         reconstruct_shards.push(shard);
                         // Reconstruction shard indices are relative to the missing indices array.

--- a/src/core.rs
+++ b/src/core.rs
@@ -484,8 +484,20 @@ impl<F: Field> ReedSolomon<F> {
         inputs: &[T],
         outputs: &mut [U],
     ) {
-        for i_input in 0..self.data_shard_count {
-            self.code_single_slice(matrix_rows, i_input, inputs[i_input].as_ref(), outputs);
+        for (i, out) in outputs.iter_mut().enumerate() {
+            let out = out.as_mut();
+
+            // Initialize the parity row `i`. Do that outside the loop below to avoid a conditional jump.
+            let coeff0 = matrix_rows[i][0];
+            let inp0 = inputs[0].as_ref();
+            F::mul_slice(coeff0, inp0, out);
+
+            // Sum up further codes on the same row `i`. Note that `j` is 0-based.
+            for (j, inp) in inputs[1..].iter().enumerate() {
+                let coeff = matrix_rows[i][j + 1];
+                let inp = inp.as_ref();
+                F::mul_slice_add(coeff, inp, out);
+            }
         }
     }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -21,7 +21,7 @@ use spin::Mutex;
 use super::Field;
 use super::ReconstructShard;
 
-const DATA_DECODE_MATRIX_CACHE_CAPACITY: usize = 254;
+const DECODE_MATRIX_CACHE_CAPACITY: usize = 254;
 
 // /// Parameters for parallelism.
 // #[derive(PartialEq, Debug, Clone, Copy)]
@@ -345,8 +345,11 @@ pub struct ReedSolomon<F: Field> {
     data_shard_count: usize,
     parity_shard_count: usize,
     total_shard_count: usize,
+    /// The matrix of encoder coefficients.
     matrix: Matrix<F>,
-    data_decode_matrix_cache: Mutex<LruCache<Vec<usize>, Arc<Matrix<F>>>>,
+    /// Cached decoder coefficient matrices, at most one matrix for each subset of
+    /// `total_shard_count` indices of size `data_shard_count`.
+    decode_matrix_cache: Mutex<LruCache<Vec<usize>, Arc<Matrix<F>>>>,
 }
 
 impl<F: Field> Clone for ReedSolomon<F> {
@@ -427,14 +430,6 @@ impl<F: Field> ReedSolomon<F> {
         parity_rows
     }
 
-    fn build_matrix(data_shards: usize, total_shards: usize) -> Matrix<F> {
-        let vandermonde = Matrix::vandermonde(total_shards, data_shards);
-
-        let top = vandermonde.sub_matrix(0, 0, data_shards, data_shards);
-
-        vandermonde.multiply(&top.invert().unwrap())
-    }
-
     /// Creates a new instance of Reed-Solomon erasure code encoder/decoder.
     ///
     /// Returns `Error::TooFewDataShards` if `data_shards == 0`.
@@ -455,14 +450,18 @@ impl<F: Field> ReedSolomon<F> {
 
         let total_shards = data_shards + parity_shards;
 
-        let matrix = Self::build_matrix(data_shards, total_shards);
+        let matrix = Matrix::encode_coeffs(data_shards, total_shards);
 
         Ok(ReedSolomon {
             data_shard_count: data_shards,
             parity_shard_count: parity_shards,
             total_shard_count: total_shards,
             matrix,
-            data_decode_matrix_cache: Mutex::new(LruCache::new(DATA_DECODE_MATRIX_CACHE_CAPACITY)),
+            decode_matrix_cache: Mutex::new(LruCache::new(
+                DECODE_MATRIX_CACHE_CAPACITY
+                    .try_into()
+                    .expect("non-0 constant; qed"),
+            )),
         })
     }
 
@@ -694,50 +693,65 @@ impl<F: Field> ReedSolomon<F> {
         self.reconstruct_internal(slices, true)
     }
 
-    fn get_data_decode_matrix(
+    /// Compute or fetch from cache the decoding coefficients for the missing shards.
+    ///
+    /// - `valid_indices` : length `self.data_shard_count`, the field element for each available shard.
+    /// - `missing_indices`: length `self.parity_shard_count`, the field element at which we want to
+    ///   evaluate/interpolate (each missing shard position). `missing_indices` must be the complement of
+    ///   `valid_indices` relative to the row indices of `self.matrix`.
+    ///
+    /// Returns an `self.data_shard_count` by `self.parity_shard_count` matrix with multiplicative
+    /// coefficients to decode the missing rows.
+    ///
+    /// The function computes the generator matrix $G = [I; E]$ where $E$ is the encode coefficients and $I$
+    /// is the identity matrix of the suitable size. Then, it splits $G$ row-wise into $G_v$ and $G_m$ - the
+    /// coefficient rows that encode available and missing shards respectively. Lastly, the returned
+    /// reconstruction coefficients are calculated as $C = G_m \cdot G_v^{-1}$.
+    ///
+    /// G is stored in the cache at the key `valid_indices`. This key is sufficient because it implies
+    /// the other dimension of $G$, that is `missing_indices`.
+    fn get_decode_matrix(
         &self,
         valid_indices: &[usize],
-        invalid_indices: &[usize],
+        missing_indices: &[usize],
     ) -> Arc<Matrix<F>> {
         {
-            let mut cache = self.data_decode_matrix_cache.lock();
-            if let Some(entry) = cache.get(invalid_indices) {
+            let mut cache = self.decode_matrix_cache.lock();
+            if let Some(entry) = cache.get(valid_indices) {
                 return entry.clone();
             }
         }
-        // Pull out the rows of the matrix that correspond to the shards that
-        // we have and build a square matrix. This matrix could be used to
-        // generate the shards that we have from the original data.
-        let mut sub_matrix = Matrix::new(self.data_shard_count, self.data_shard_count);
-        for (sub_matrix_row, &valid_index) in valid_indices.iter().enumerate() {
-            for c in 0..self.data_shard_count {
-                sub_matrix.set(sub_matrix_row, c, self.matrix.get(valid_index, c));
-            }
-        }
-        // Invert the matrix, so we can go from the encoded shards back to the
-        // original data. Then pull out the row that generates the shard that
-        // we want to decode. Note that since this matrix maps back to the
-        // original data, it can be used to create a data shard, but not a
-        // parity shard.
-        let data_decode_matrix = Arc::new(sub_matrix.invert().unwrap());
-        // Cache the inverted matrix for future use keyed on the indices of the
-        // invalid rows.
+
+        let encode_coeffs_rows = self.matrix.rows();
+
+        let valid_rows = valid_indices
+            .iter()
+            .map(|i| encode_coeffs_rows[*i])
+            .collect();
+        let gv = Matrix::from_rows(valid_rows);
+        let gv_inv = gv.invert().unwrap();
+
+        let missing_rows = missing_indices
+            .iter()
+            .map(|i| encode_coeffs_rows[*i])
+            .collect();
+        let gm = Matrix::from_rows(missing_rows);
+
+        let decode_coeffs = Arc::new(gm.multiply(&gv_inv));
         {
-            let data_decode_matrix = data_decode_matrix.clone();
-            let mut cache = self.data_decode_matrix_cache.lock();
-            cache.put(Vec::from(invalid_indices), data_decode_matrix);
+            let decode_coeffs = decode_coeffs.clone();
+            let mut cache = self.decode_matrix_cache.lock();
+            cache.put(Vec::from(valid_indices), decode_coeffs);
         }
-        data_decode_matrix
+        decode_coeffs
     }
 
     fn reconstruct_internal<T: ReconstructShard<F>>(
         &self,
         shards: &mut [T],
-        data_only: bool,
+        data_only: bool, // FIXME
     ) -> Result<(), Error> {
         check_piece_count!(all => self, shards);
-
-        let data_shard_count = self.data_shard_count;
 
         // Quick check: are all of the shards present?  If so, there's
         // nothing to do.
@@ -767,7 +781,7 @@ impl<F: Field> ReedSolomon<F> {
         }
 
         // More complete sanity check
-        if number_present < data_shard_count {
+        if number_present < self.data_shard_count {
             return Err(Error::TooFewShardsPresent);
         }
 
@@ -779,146 +793,68 @@ impl<F: Field> ReedSolomon<F> {
         // the missing data shards.
         //
         // Also, create an array of indices of the valid rows we do have
-        // and the invalid rows we don't have.
+        // and the missing rows.
         //
         // The valid indices are used to construct the data decode matrix,
-        // the invalid indices are used to key the data decode matrix
-        // in the data decode matrix cache.
+        // and as key in the data decode matrix cache.
         //
-        // We only need exactly N valid indices, where N = `data_shard_count`,
-        // as the data decode matrix is a N x N matrix, thus only needs
+        // We need exactly N valid indices, where N = `data_shard_count`,
+        // as the data decode matrix is a N x N matrix, thus needs
         // N valid indices for determining the N rows to pick from
         // `self.matrix`.
-        let mut sub_shards: SmallVec<[&[F::Elem]; 32]> = SmallVec::with_capacity(data_shard_count);
-        let mut missing_data_slices: SmallVec<[&mut [F::Elem]; 32]> =
+        let mut valid_shards: SmallVec<[&[F::Elem]; 32]> =
+            SmallVec::with_capacity(self.data_shard_count);
+        let mut valid_indices: SmallVec<[usize; 32]> =
+            SmallVec::with_capacity(self.data_shard_count);
+        // the complement of valid_indices
+        let mut missing_indices: SmallVec<[usize; 32]> =
             SmallVec::with_capacity(self.parity_shard_count);
-        let mut missing_parity_slices: SmallVec<[&mut [F::Elem]; 32]> =
+        // content of the output shards
+        let mut reconstruct_shards: SmallVec<[&mut [F::Elem]; 32]> =
             SmallVec::with_capacity(self.parity_shard_count);
-        let mut valid_indices: SmallVec<[usize; 32]> = SmallVec::with_capacity(data_shard_count);
-        let mut invalid_indices: SmallVec<[usize; 32]> = SmallVec::with_capacity(data_shard_count);
+        // reconstruct_indices indexes missing_indices
+        let mut reconstruct_indices: SmallVec<[usize; 32]> =
+            SmallVec::with_capacity(self.parity_shard_count);
 
         // Separate the shards into groups
         for (matrix_row, shard) in shards.iter_mut().enumerate() {
-            // get or initialize the shard so we can reconstruct in-place,
-            // but if we are only reconstructing data shard,
-            // do not initialize if the shard is not a data shard
-            let shard_data = if matrix_row >= data_shard_count && data_only {
-                shard.get().ok_or(None)
-            } else {
-                shard.get_or_initialize(shard_len).map_err(Some)
-            };
-
-            match shard_data {
+            match shard.get_or_initialize(shard_len) {
                 Ok(shard) => {
-                    if sub_shards.len() < data_shard_count {
-                        sub_shards.push(shard);
+                    if valid_shards.len() < self.data_shard_count {
+                        valid_shards.push(shard);
                         valid_indices.push(matrix_row);
                     } else {
-                        // Already have enough shards in `sub_shards`
-                        // as we only need N shards, where N = `data_shard_count`,
-                        // for the data decode matrix
-                        //
-                        // So nothing to do here
+                        missing_indices.push(matrix_row);
                     }
                 }
-                Err(None) => {
+                Err(Err(_)) => {
                     // the shard data is not meant to be initialized here,
                     // but we should still note it missing.
-                    invalid_indices.push(matrix_row);
+                    missing_indices.push(matrix_row);
                 }
-                Err(Some(x)) => {
-                    // initialized missing shard data.
-                    let shard = x?;
-                    if matrix_row < data_shard_count {
-                        missing_data_slices.push(shard);
-                    } else {
-                        missing_parity_slices.push(shard);
-                    }
-
-                    invalid_indices.push(matrix_row);
+                Err(Ok(shard)) => {
+                    reconstruct_shards.push(shard);
+                    // Reconstruction shard indices are relative to the missing indices array.
+                    reconstruct_indices.push(missing_indices.len());
+                    missing_indices.push(matrix_row);
                 }
             }
         }
 
-        let data_decode_matrix = self.get_data_decode_matrix(&valid_indices, &invalid_indices);
+        let decode_matrix = self.get_decode_matrix(&valid_indices, &missing_indices);
 
-        // Re-create any data shards that were missing.
-        //
-        // The input to the coding is all of the shards we actually
-        // have, and the output is the missing data shards. The computation
-        // is done using the special decode matrix we just built.
-        let mut matrix_rows: SmallVec<[&[F::Elem]; 32]> =
-            SmallVec::with_capacity(self.parity_shard_count);
-
-        for i_slice in invalid_indices
+        // Decode coefficient matrix to recover the desired shards, data and parity alike
+        let reconstruct_decode_rows: SmallVec<[&[F::Elem]; 32]> = reconstruct_indices
             .iter()
-            .cloned()
-            .take_while(|i| i < &data_shard_count)
-        {
-            matrix_rows.push(data_decode_matrix.get_row(i_slice));
-        }
+            .map(|i| decode_matrix.get_row(*i))
+            .collect();
 
-        self.code_some_slices(&matrix_rows, &sub_shards, &mut missing_data_slices);
+        self.code_some_slices(
+            &reconstruct_decode_rows,
+            &valid_shards,
+            &mut reconstruct_shards,
+        );
 
-        if data_only {
-            Ok(())
-        } else {
-            // Now that we have all of the data shards intact, we can
-            // compute any of the parity that is missing.
-            //
-            // The input to the coding is ALL of the data shards, including
-            // any that we just calculated.  The output is whichever of the
-            // parity shards were missing.
-            let mut matrix_rows: SmallVec<[&[F::Elem]; 32]> =
-                SmallVec::with_capacity(self.parity_shard_count);
-            let parity_rows = self.get_parity_rows();
-
-            for i_slice in invalid_indices
-                .iter()
-                .cloned()
-                .skip_while(|i| i < &data_shard_count)
-            {
-                matrix_rows.push(parity_rows[i_slice - data_shard_count]);
-            }
-            {
-                // Gather up all the data shards.
-                // old data shards are in `sub_shards`,
-                // new ones are in `missing_data_slices`.
-                let mut i_old_data_slice = 0;
-                let mut i_new_data_slice = 0;
-
-                let mut all_data_slices: SmallVec<[&[F::Elem]; 32]> =
-                    SmallVec::with_capacity(data_shard_count);
-
-                let mut next_maybe_good = 0;
-                let mut push_good_up_to = move |data_slices: &mut SmallVec<_>, up_to| {
-                    // if next_maybe_good == up_to, this loop is a no-op.
-                    for _ in next_maybe_good..up_to {
-                        // push all good indices we just skipped.
-                        data_slices.push(sub_shards[i_old_data_slice]);
-                        i_old_data_slice += 1;
-                    }
-
-                    next_maybe_good = up_to + 1;
-                };
-
-                for i_slice in invalid_indices
-                    .iter()
-                    .cloned()
-                    .take_while(|i| i < &data_shard_count)
-                {
-                    push_good_up_to(&mut all_data_slices, i_slice);
-                    all_data_slices.push(missing_data_slices[i_new_data_slice]);
-                    i_new_data_slice += 1;
-                }
-                push_good_up_to(&mut all_data_slices, data_shard_count);
-
-                // Now do the actual computation for the missing
-                // parity shards
-                self.code_some_slices(&matrix_rows, &all_data_slices, &mut missing_parity_slices);
-            }
-
-            Ok(())
-        }
+        Ok(())
     }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -22,6 +22,7 @@ use super::Field;
 use super::ReconstructShard;
 
 const DECODE_MATRIX_CACHE_CAPACITY: usize = 254;
+const SHARD_COUNT_ON_STACK: usize = 32;
 
 // /// Parameters for parallelism.
 // #[derive(PartialEq, Debug, Clone, Copy)]
@@ -420,7 +421,7 @@ impl<F: Field> ReedSolomon<F> {
     //   - check consistency of length of individual slices
     //   - check length of `slice_present` matches length of `slices`
 
-    fn get_parity_rows(&self) -> SmallVec<[&[F::Elem]; 32]> {
+    fn get_parity_rows(&self) -> SmallVec<[&[F::Elem]; SHARD_COUNT_ON_STACK]> {
         let mut parity_rows = SmallVec::with_capacity(self.parity_shard_count);
         let matrix = &self.matrix;
         for i in self.data_shard_count..self.total_shard_count {
@@ -639,7 +640,7 @@ impl<F: Field> ReedSolomon<F> {
 
         let slice_len = slices[0].as_ref().len();
 
-        let mut buffer: SmallVec<[Vec<F::Elem>; 32]> =
+        let mut buffer: SmallVec<[Vec<F::Elem>; SHARD_COUNT_ON_STACK]> =
             SmallVec::with_capacity(self.parity_shard_count);
 
         for _ in 0..self.parity_shard_count {
@@ -749,7 +750,7 @@ impl<F: Field> ReedSolomon<F> {
     fn reconstruct_internal<T: ReconstructShard<F>>(
         &self,
         shards: &mut [T],
-        data_only: bool, // FIXME
+        data_only: bool,
     ) -> Result<(), Error> {
         check_piece_count!(all => self, shards);
 
@@ -802,41 +803,42 @@ impl<F: Field> ReedSolomon<F> {
         // as the data decode matrix is a N x N matrix, thus needs
         // N valid indices for determining the N rows to pick from
         // `self.matrix`.
-        let mut valid_shards: SmallVec<[&[F::Elem]; 32]> =
+        let mut valid_shards: SmallVec<[&[F::Elem]; SHARD_COUNT_ON_STACK]> =
             SmallVec::with_capacity(self.data_shard_count);
-        let mut valid_indices: SmallVec<[usize; 32]> =
+        let mut valid_indices: SmallVec<[usize; SHARD_COUNT_ON_STACK]> =
             SmallVec::with_capacity(self.data_shard_count);
         // the complement of valid_indices
-        let mut missing_indices: SmallVec<[usize; 32]> =
+        let mut missing_indices: SmallVec<[usize; SHARD_COUNT_ON_STACK]> =
             SmallVec::with_capacity(self.parity_shard_count);
         // content of the output shards
-        let mut reconstruct_shards: SmallVec<[&mut [F::Elem]; 32]> =
+        let mut reconstruct_shards: SmallVec<[&mut [F::Elem]; SHARD_COUNT_ON_STACK]> =
             SmallVec::with_capacity(self.parity_shard_count);
         // reconstruct_indices indexes missing_indices
-        let mut reconstruct_indices: SmallVec<[usize; 32]> =
+        let mut reconstruct_indices: SmallVec<[usize; SHARD_COUNT_ON_STACK]> =
             SmallVec::with_capacity(self.parity_shard_count);
 
-        // Separate the shards into groups
-        for (matrix_row, shard) in shards.iter_mut().enumerate() {
+        for (shard_idx, shard) in shards.iter_mut().enumerate() {
             match shard.get_or_initialize(shard_len) {
                 Ok(shard) => {
                     if valid_shards.len() < self.data_shard_count {
                         valid_shards.push(shard);
-                        valid_indices.push(matrix_row);
+                        valid_indices.push(shard_idx);
                     } else {
-                        missing_indices.push(matrix_row);
+                        missing_indices.push(shard_idx);
                     }
                 }
                 Err(Err(_)) => {
                     // the shard data is not meant to be initialized here,
                     // but we should still note it missing.
-                    missing_indices.push(matrix_row);
+                    missing_indices.push(shard_idx);
                 }
                 Err(Ok(shard)) => {
-                    reconstruct_shards.push(shard);
-                    // Reconstruction shard indices are relative to the missing indices array.
-                    reconstruct_indices.push(missing_indices.len());
-                    missing_indices.push(matrix_row);
+                    if !data_only || shard_idx < self.data_shard_count {
+                        reconstruct_shards.push(shard);
+                        // Reconstruction shard indices are relative to the missing indices array.
+                        reconstruct_indices.push(missing_indices.len());
+                    }
+                    missing_indices.push(shard_idx);
                 }
             }
         }
@@ -844,10 +846,11 @@ impl<F: Field> ReedSolomon<F> {
         let decode_matrix = self.get_decode_matrix(&valid_indices, &missing_indices);
 
         // Decode coefficient matrix to recover the desired shards, data and parity alike
-        let reconstruct_decode_rows: SmallVec<[&[F::Elem]; 32]> = reconstruct_indices
-            .iter()
-            .map(|i| decode_matrix.get_row(*i))
-            .collect();
+        let reconstruct_decode_rows: SmallVec<[&[F::Elem]; SHARD_COUNT_ON_STACK]> =
+            reconstruct_indices
+                .iter()
+                .map(|i| decode_matrix.get_row(*i))
+                .collect();
 
         self.code_some_slices(
             &reconstruct_decode_rows,

--- a/src/galois_16.rs
+++ b/src/galois_16.rs
@@ -34,6 +34,10 @@ impl crate::Field for Field {
         (Element(a) / Element(b)).0
     }
 
+    fn inv(a: [u8; 2]) -> [u8; 2] {
+        Element(a).inverse().0
+    }
+
     fn exp(elem: [u8; 2], n: usize) -> [u8; 2] {
         Element(elem).exp(n).0
     }
@@ -44,6 +48,10 @@ impl crate::Field for Field {
 
     fn one() -> [u8; 2] {
         [0, 1]
+    }
+
+    fn generator() -> [u8; 2] {
+        [0, 2]
     }
 
     fn nth_internal(n: usize) -> [u8; 2] {
@@ -107,11 +115,7 @@ impl Element {
     }
 
     fn degree(&self) -> usize {
-        if self.0[0] != 0 {
-            1
-        } else {
-            0
-        }
+        if self.0[0] != 0 { 1 } else { 0 }
     }
 }
 
@@ -318,12 +322,12 @@ impl Element {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quickcheck::Arbitrary;
+    use quickcheck::{Arbitrary, Gen};
 
     impl Arbitrary for Element {
-        fn arbitrary<G: quickcheck::Gen>(gen: &mut G) -> Self {
-            let a = u8::arbitrary(gen);
-            let b = u8::arbitrary(gen);
+        fn arbitrary(g: &mut Gen) -> Self {
+            let a = u8::arbitrary(g);
+            let b = u8::arbitrary(g);
 
             Element([a, b])
         }

--- a/src/galois_8.rs
+++ b/src/galois_8.rs
@@ -22,6 +22,10 @@ impl crate::Field for Field {
         div(a, b)
     }
 
+    fn inv(a: u8) -> u8 {
+        inv(a)
+    }
+
     fn exp(elem: u8, n: usize) -> u8 {
         exp(elem, n)
     }
@@ -32,6 +36,10 @@ impl crate::Field for Field {
 
     fn one() -> u8 {
         1
+    }
+
+    fn generator() -> u8 {
+        2
     }
 
     fn nth_internal(n: usize) -> u8 {
@@ -84,6 +92,12 @@ pub fn div(a: u8, b: u8) -> u8 {
         }
         EXP_TABLE[log_result as usize]
     }
+}
+
+pub fn inv(a: u8) -> u8 {
+    assert_ne!(a, 0, "0 is not invertible");
+    let la = LOG_TABLE[a as usize] as usize;
+    EXP_TABLE[255 - la]
 }
 
 /// Compute a^n.
@@ -264,7 +278,7 @@ fn slice_xor(input: &[u8], out: &mut [u8]) {
     not(target_env = "msvc"),
     not(any(target_os = "android", target_os = "ios"))
 ))]
-extern "C" {
+unsafe extern "C" {
     fn reedsolomon_gal_mul(
         low: *const u8,
         high: *const u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,9 @@ pub trait Field: Sized {
     /// Divide a by b. Panics is b is zero.
     fn div(a: Self::Elem, b: Self::Elem) -> Self::Elem;
 
+    /// Multiplicative inverse of `a`.
+    fn inv(a: Self::Elem) -> Self::Elem;
+
     /// Raise `a` to the n'th power.
     fn exp(a: Self::Elem, n: usize) -> Self::Elem;
 
@@ -78,6 +81,9 @@ pub trait Field: Sized {
 
     /// The "one" element or multiplicative identity.
     fn one() -> Self::Elem;
+
+    /// Generator element.
+    fn generator() -> Self::Elem;
 
     fn nth_internal(n: usize) -> Self::Elem;
 
@@ -157,11 +163,7 @@ impl<F: Field, T: AsRef<[F::Elem]> + AsMut<[F::Elem]> + FromIterator<F::Elem>> R
             .get_or_insert_with(|| iter::repeat(F::zero()).take(len).collect())
             .as_mut();
 
-        if is_some {
-            Ok(x)
-        } else {
-            Err(Ok(x))
-        }
+        if is_some { Ok(x) } else { Err(Ok(x)) }
     }
 }
 
@@ -175,11 +177,7 @@ impl<F: Field, T: AsRef<[F::Elem]> + AsMut<[F::Elem]>> ReconstructShard<F> for (
     }
 
     fn get(&mut self) -> Option<&mut [F::Elem]> {
-        if !self.1 {
-            None
-        } else {
-            Some(self.0.as_mut())
-        }
+        if !self.1 { None } else { Some(self.0.as_mut()) }
     }
 
     fn get_or_initialize(
@@ -188,11 +186,7 @@ impl<F: Field, T: AsRef<[F::Elem]> + AsMut<[F::Elem]>> ReconstructShard<F> for (
     ) -> Result<&mut [F::Elem], Result<&mut [F::Elem], Error>> {
         let x = self.0.as_mut();
         if x.len() == len {
-            if self.1 {
-                Ok(x)
-            } else {
-                Err(Ok(x))
-            }
+            if self.1 { Ok(x) } else { Err(Ok(x)) }
         } else {
             Err(Err(Error::IncorrectShardSize))
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ fn log2(n: f32) -> f32 {
 }
 
 /// A finite field to perform encoding over.
-pub trait Field: Sized {
+pub trait Field: Sized + std::fmt::Debug {
     /// The order of the field. This is a limit on the number of shards
     /// in an encoding.
     const ORDER: usize;

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -11,30 +11,12 @@ const ROW_ARRAY_STACK_LENGTH: usize = 64;
 /// Maximum length of the matrix data array in stack, exceeding which leads to heap allocation.
 const DATA_ARRAY_STACK_LENGTH: usize = 1024;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     SingularMatrix,
 }
 
-macro_rules! acc {
-    (
-        $m:ident, $r:expr, $c:expr
-    ) => {
-        $m.data[$r * $m.col_count + $c]
-    };
-}
-
-pub fn flatten<T>(m: Vec<Vec<T>>) -> Vec<T> {
-    let mut result: Vec<T> = Vec::with_capacity(m.len() * m[0].len());
-    for row in m {
-        for v in row {
-            result.push(v);
-        }
-    }
-    result
-}
-
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Matrix<F: Field> {
     row_count: usize,
     col_count: usize,
@@ -42,19 +24,13 @@ pub struct Matrix<F: Field> {
     data: SmallVec<[F::Elem; DATA_ARRAY_STACK_LENGTH]>,
 }
 
-fn calc_matrix_row_start_end(col_count: usize, row: usize) -> (usize, usize) {
-    let start = row * col_count;
-    let end = start + col_count;
+type RowRef<'a, T> = &'a [T];
+type RowRefArr<'a, T> = SmallVec<[RowRef<'a, T>; ROW_ARRAY_STACK_LENGTH]>;
 
-    (start, end)
-}
+type RowMut<'a, T> = &'a mut [T];
+type RowMutArr<'a, T> = SmallVec<[RowMut<'a, T>; ROW_ARRAY_STACK_LENGTH]>;
 
-pub type RowRef<'a, T> = &'a [T];
-pub type RowRefArr<'a, T> = SmallVec<[RowRef<'a, T>; ROW_ARRAY_STACK_LENGTH]>;
-
-pub type RowMut<'a, T> = &'a mut [T];
-pub type RowMutArr<'a, T> = SmallVec<[RowMut<'a, T>; ROW_ARRAY_STACK_LENGTH]>;
-
+#[derive(Debug, PartialEq, Eq)]
 pub struct SubmatrixMut<'a, F: Field> {
     row_count: usize,
     col_count: usize,
@@ -62,7 +38,7 @@ pub struct SubmatrixMut<'a, F: Field> {
 }
 
 impl<'a, F: Field> SubmatrixMut<'a, F> {
-    pub fn new(row_count: usize, col_count: usize, rows: RowMutArr<'a, F::Elem>) -> Self {
+    fn new(row_count: usize, col_count: usize, rows: RowMutArr<'a, F::Elem>) -> Self {
         debug_assert_eq!(rows.len(), row_count);
         debug_assert!(rows.iter().all(|row| row.len() == col_count));
 
@@ -74,7 +50,7 @@ impl<'a, F: Field> SubmatrixMut<'a, F> {
     }
 
     /// Write the identity matrix into the rows.
-    pub fn make_identity(&mut self) {
+    fn make_identity(&mut self) {
         for (i, row) in self.rows.iter_mut().enumerate() {
             for (j, a) in row.iter_mut().enumerate() {
                 *a = if i == j { F::one() } else { F::zero() }
@@ -83,24 +59,37 @@ impl<'a, F: Field> SubmatrixMut<'a, F> {
     }
 
     /// Write the Vandermonde matrix into the rows.
-    pub fn make_vandermonde(&mut self) {
-        for i in 0..self.row_count {
-            let row_gen = F::exp(F::generator(), i + 1);
-            for j in 0..self.col_count {
-                let a = F::exp(row_gen, j);
-                self.rows[i][j] = a;
+    fn make_vandermonde(&mut self) {
+        for (i, row) in self.rows.iter_mut().enumerate() {
+            // FIXME: row_gen should be non-0 and unique, such as in
+            // let row_gen = F::exp(F::generator(), i + 1);
+            // Below is the crate v6.0 behaviour that leads to row_gen(0) == 0
+            // and the first row being all ones.
+            let row_gen = F::nth(i);
+            for (j, a) in row.iter_mut().enumerate() {
+                *a = F::exp(row_gen, j);
             }
         }
     }
 
-    /// In-place Gaussian elimination.
-    pub fn gaussian_elim(&mut self) -> Result<(), Error> {
-        let n = self.row_count;
+    /// Swap rows in place.
+    fn swap_rows(&mut self, row1: usize, row2: usize) {
+        let (first, second) = if row1 < row2 {
+            (row1, row2)
+        } else {
+            (row2, row1)
+        };
 
-        for i in 0..n {
+        let (left, right) = self.rows.split_at_mut(second);
+        left[first].swap_with_slice(right[0]);
+    }
+
+    /// In-place Gaussian elimination.
+    fn gaussian_elim(&mut self) -> Result<(), Error> {
+        for i in 0..self.row_count {
             // Find pivot
             let mut pivot_row = None;
-            for r in i..n {
+            for r in i..self.row_count {
                 if self.rows[r][i] != F::zero() {
                     pivot_row = Some(r);
                     break;
@@ -110,7 +99,7 @@ impl<'a, F: Field> SubmatrixMut<'a, F> {
 
             // Swap to top
             if pivot_row != i {
-                self.rows.swap(i, pivot_row);
+                self.swap_rows(i, pivot_row);
             }
 
             // Scale pivot to 1
@@ -120,52 +109,46 @@ impl<'a, F: Field> SubmatrixMut<'a, F> {
             }
 
             // Eliminate other rows
-            for r in 0..n {
+            for r in 0..self.row_count {
                 if r != i && self.rows[r][i] != F::zero() {
                     let factor = self.rows[r][i];
-                    for j in 0..2 * n {
+                    for j in 0..self.col_count {
                         let a = self.rows[r][j];
                         self.rows[r][j] = F::add(a, F::mul(factor, self.rows[i][j]));
                     }
                 }
             }
         }
-
         Ok(())
     }
 }
 
 impl<F: Field> Matrix<F> {
-    fn calc_row_start_end(&self, row: usize) -> (usize, usize) {
-        calc_matrix_row_start_end(self.col_count, row)
-    }
+    // TODO: rename to `zero` since this in effect outputs a zero matrix.
+    pub fn new(row_count: usize, col_count: usize) -> Self {
+        let data = SmallVec::from_vec(vec![F::zero(); row_count * col_count]);
 
-    // TODO: rename to `zero`
-    pub fn new(rows: usize, cols: usize) -> Matrix<F> {
-        let data = SmallVec::from_vec(vec![F::zero(); rows * cols]);
-
-        Matrix {
-            row_count: rows,
-            col_count: cols,
+        Self {
+            row_count,
+            col_count,
             data,
         }
     }
 
-    pub fn new_with_data(init_data: Vec<Vec<F::Elem>>) -> Matrix<F> {
-        let rows = init_data.len();
-        let cols = init_data[0].len();
+    pub fn new_with_data(rows: &[Vec<F::Elem>]) -> Self {
+        let row_count = rows.len();
+        let col_count = rows[0].len();
 
-        for r in init_data.iter() {
-            if r.len() != cols {
-                panic!("Inconsistent row sizes")
-            }
-        }
+        assert!(
+            rows.iter().all(|r| r.len() == col_count),
+            "Inconsistent row sizes"
+        );
 
-        let data = SmallVec::from_vec(flatten(init_data));
+        let data = SmallVec::from_vec(rows.iter().flatten().copied().collect());
 
-        Matrix {
-            row_count: rows,
-            col_count: cols,
+        Self {
+            row_count,
+            col_count,
             data,
         }
     }
@@ -190,7 +173,7 @@ impl<F: Field> Matrix<F> {
     }
 
     #[cfg(test)]
-    pub fn make_random(size: usize) -> Matrix<F>
+    pub fn make_random(size: usize) -> Self
     where
         rand::distr::StandardUniform: rand::distr::Distribution<F::Elem>,
     {
@@ -199,13 +182,14 @@ impl<F: Field> Matrix<F> {
             crate::tests::fill_random(v);
         }
 
-        Matrix::new_with_data(vec)
+        Self::new_with_data(&vec)
     }
 
-    pub fn identity(size: usize) -> Matrix<F> {
+    #[cfg(test)]
+    pub fn identity(size: usize) -> Self {
         let mut result = Self::new(size, size);
         for i in 0..size {
-            acc!(result, i, i) = F::one();
+            result.set(i, i, F::one());
         }
         result
     }
@@ -218,37 +202,37 @@ impl<F: Field> Matrix<F> {
         self.row_count
     }
 
-    pub fn get(&self, r: usize, c: usize) -> F::Elem {
-        acc!(self, r, c).clone()
+    pub fn get(&self, row: usize, col: usize) -> F::Elem {
+        self.data[row * self.col_count + col]
     }
 
-    pub fn set(&mut self, r: usize, c: usize, val: F::Elem) {
-        acc!(self, r, c) = val;
+    pub fn set(&mut self, row: usize, col: usize, val: F::Elem) {
+        self.data[row * self.col_count + col] = val;
     }
 
-    pub fn multiply(&self, rhs: &Matrix<F>) -> Matrix<F> {
-        if self.col_count != rhs.row_count {
-            panic!(
-                "Colomn count on left is different from row count on right, lhs: {}, rhs: {}",
-                self.col_count, rhs.row_count
-            )
-        }
+    pub fn multiply(&self, rhs: &Matrix<F>) -> Self {
+        assert_eq!(
+            self.col_count, rhs.row_count,
+            "Colomn count on left is different from row count on right, lhs: {}, rhs: {}",
+            self.col_count, rhs.row_count
+        );
+
         let mut result = Self::new(self.row_count, rhs.col_count);
         for r in 0..self.row_count {
             for c in 0..rhs.col_count {
                 let mut val = F::zero();
                 for i in 0..self.col_count {
-                    let mul = F::mul(acc!(self, r, i).clone(), acc!(rhs, i, c).clone());
+                    let mul = F::mul(self.get(r, i), rhs.get(i, c));
 
                     val = F::add(val, mul);
                 }
-                acc!(result, r, c) = val;
+                result.set(r, c, val);
             }
         }
         result
     }
 
-    pub fn augment_with_identity(&self) -> Matrix<F> {
+    fn augment_with_identity(&self) -> Self {
         let n = self.row_count;
         let mut aug = Matrix::new(n, 2 * n);
 
@@ -262,41 +246,16 @@ impl<F: Field> Matrix<F> {
         aug
     }
 
-    pub fn submatrix<R, C>(&self, row_range: R, col_range: C) -> Self
+    fn submatrix<R, C>(&self, row_range: R, col_range: C) -> Self
     where
         R: std::ops::RangeBounds<usize>,
         C: std::ops::RangeBounds<usize>,
     {
-        use std::ops::Bound::*;
+        let b = self.matrix_bounds(row_range, col_range);
 
-        let row_start = match row_range.start_bound() {
-            Included(&x) => x,
-            Excluded(&x) => x + 1,
-            Unbounded => 0,
-        };
-        let row_end = match row_range.end_bound() {
-            Included(&x) => x + 1,
-            Excluded(&x) => x,
-            Unbounded => self.row_count,
-        };
-
-        let col_start = match col_range.start_bound() {
-            Included(&x) => x,
-            Excluded(&x) => x + 1,
-            Unbounded => 0,
-        };
-        let col_end = match col_range.end_bound() {
-            Included(&x) => x + 1,
-            Excluded(&x) => x,
-            Unbounded => self.col_count,
-        };
-
-        let row_count = row_end - row_start;
-        let col_count = col_end - col_start;
-
-        let mut m = Matrix::new(row_count, col_count);
-        for (r, i) in (row_start..row_end).zip(0..) {
-            for (c, j) in (col_start..col_end).zip(0..) {
+        let mut m = Matrix::new(b.row_count, b.col_count);
+        for (r, i) in (b.row_start..b.row_end).zip(0..) {
+            for (c, j) in (b.col_start..b.col_end).zip(0..) {
                 m.set(i, j, self.get(r, c));
             }
         }
@@ -304,47 +263,22 @@ impl<F: Field> Matrix<F> {
         m
     }
 
-    pub fn submatrix_mut<'a, R, C>(&'a mut self, row_range: R, col_range: C) -> SubmatrixMut<'a, F>
+    fn submatrix_mut<'a, R, C>(&'a mut self, row_range: R, col_range: C) -> SubmatrixMut<'a, F>
     where
         R: std::ops::RangeBounds<usize>,
         C: std::ops::RangeBounds<usize>,
     {
-        use std::ops::Bound::*;
-
-        let row_start = match row_range.start_bound() {
-            Included(&x) => x,
-            Excluded(&x) => x + 1,
-            Unbounded => 0,
-        };
-        let row_end = match row_range.end_bound() {
-            Included(&x) => x + 1,
-            Excluded(&x) => x,
-            Unbounded => self.row_count,
-        };
-
-        let col_start = match col_range.start_bound() {
-            Included(&x) => x,
-            Excluded(&x) => x + 1,
-            Unbounded => 0,
-        };
-        let col_end = match col_range.end_bound() {
-            Included(&x) => x + 1,
-            Excluded(&x) => x,
-            Unbounded => self.col_count,
-        };
-
-        let row_count = row_end - row_start;
-        let col_count = col_end - col_start;
+        let b = self.matrix_bounds(row_range, col_range);
         let base_ptr = self.data.as_mut_ptr();
 
-        let rows: RowMutArr<'a, F::Elem> = (row_start..row_end)
+        let rows: RowMutArr<'a, F::Elem> = (b.row_start..b.row_end)
             .map(|i| unsafe {
-                let row_ptr = base_ptr.add(i * self.col_count + col_start);
-                std::slice::from_raw_parts_mut(row_ptr, col_count)
+                let row_ptr = base_ptr.add(i * self.col_count + b.col_start);
+                std::slice::from_raw_parts_mut(row_ptr, b.col_count)
             })
             .collect();
 
-        SubmatrixMut::new(row_count, col_count, rows)
+        SubmatrixMut::new(b.row_count, b.col_count, rows)
     }
 
     pub fn rows<'a>(&'a self) -> RowRefArr<'a, F::Elem> {
@@ -356,32 +290,18 @@ impl<F: Field> Matrix<F> {
     }
 
     pub fn get_row(&self, row: usize) -> &[F::Elem] {
-        let (start, end) = self.calc_row_start_end(row);
+        let start = row * self.col_count;
+        let end = start + self.col_count;
 
         &self.data[start..end]
-    }
-
-    pub fn swap_rows(&mut self, r1: usize, r2: usize) {
-        let (r1_s, _) = self.calc_row_start_end(r1);
-        let (r2_s, _) = self.calc_row_start_end(r2);
-
-        if r1 == r2 {
-            return;
-        } else {
-            for i in 0..self.col_count {
-                self.data.swap(r1_s + i, r2_s + i);
-            }
-        }
     }
 
     pub fn is_square(&self) -> bool {
         self.row_count == self.col_count
     }
 
-    pub fn invert<'a>(&'a self) -> Result<Matrix<F>, Error> {
-        if !self.is_square() {
-            panic!("Trying to invert a non-square matrix")
-        }
+    pub fn invert(&self) -> Result<Self, Error> {
+        assert!(self.is_square(), "Trying to invert a non-square matrix");
 
         let mut aug = self.augment_with_identity();
         {
@@ -392,7 +312,7 @@ impl<F: Field> Matrix<F> {
         Ok(aug.submatrix(0..aug.row_count, aug.row_count..aug.col_count))
     }
 
-    pub fn encode_coeffs(data_shards: usize, total_shards: usize) -> Matrix<F> {
+    pub fn encode_coeffs(data_shards: usize, total_shards: usize) -> Self {
         let mut mat = Self::new(total_shards, data_shards);
         {
             let mut top_square = mat.submatrix_mut(0..data_shards, 0..data_shards);
@@ -404,6 +324,57 @@ impl<F: Field> Matrix<F> {
         }
         mat
     }
+
+    fn matrix_bounds<R, C>(&self, row_range: R, col_range: C) -> MatrixBounds
+    where
+        R: std::ops::RangeBounds<usize>,
+        C: std::ops::RangeBounds<usize>,
+    {
+        use std::ops::Bound::*;
+
+        let row_start = match row_range.start_bound() {
+            Included(&x) => x,
+            Excluded(&x) => x + 1,
+            Unbounded => 0,
+        };
+        let row_end = match row_range.end_bound() {
+            Included(&x) => x + 1,
+            Excluded(&x) => x,
+            Unbounded => self.row_count,
+        };
+
+        let col_start = match col_range.start_bound() {
+            Included(&x) => x,
+            Excluded(&x) => x + 1,
+            Unbounded => 0,
+        };
+        let col_end = match col_range.end_bound() {
+            Included(&x) => x + 1,
+            Excluded(&x) => x,
+            Unbounded => self.col_count,
+        };
+
+        let row_count = row_end - row_start;
+        let col_count = col_end - col_start;
+
+        MatrixBounds {
+            row_count,
+            col_count,
+            row_start,
+            row_end,
+            col_start,
+            col_end,
+        }
+    }
+}
+
+struct MatrixBounds {
+    row_count: usize,
+    col_count: usize,
+    row_start: usize,
+    row_end: usize,
+    col_start: usize,
+    col_end: usize,
 }
 
 #[cfg(test)]
@@ -421,7 +392,7 @@ mod tests {
                 [ $( $x:expr ),+ ]
             ),*
         ) => (
-            Matrix::<galois_8::Field>::new_with_data(vec![ $( vec![$( $x ),*] ),* ])
+            Matrix::<galois_8::Field>::new_with_data(&[ $( vec![$( $x ),*] ),* ])
         );
         ($rows:expr, $cols:expr) => (Matrix::new($rows, $cols));
     }
@@ -449,26 +420,6 @@ mod tests {
     }
 
     #[test]
-    fn test_matrix_swap_rows() {
-        {
-            let mut m1 = matrix!([1, 2, 3], [4, 5, 6], [7, 8, 9]);
-            let expect = matrix!([7, 8, 9], [4, 5, 6], [1, 2, 3]);
-            m1.swap_rows(0, 2);
-            assert_eq!(expect, m1);
-        }
-        {
-            let mut m1 = matrix!([1, 2, 3], [4, 5, 6], [7, 8, 9]);
-            let expect = m1.clone();
-            m1.swap_rows(0, 0);
-            assert_eq!(expect, m1);
-            m1.swap_rows(1, 1);
-            assert_eq!(expect, m1);
-            m1.swap_rows(2, 2);
-            assert_eq!(expect, m1);
-        }
-    }
-
-    #[test]
     #[should_panic]
     fn test_inconsistent_row_sizes() {
         matrix!([1, 0, 0], [0, 1], [0, 0, 1]);
@@ -488,7 +439,7 @@ mod tests {
         let m1 = matrix!([0, 1], [2, 3]);
 
         let m2 = m1.augment_with_identity();
-        let m2_right = m2.sub_matrix(0, 2, 4, 4);
+        let m2_right = m2.submatrix(0..2, 2..4);
 
         assert_eq!(m2_right, Matrix::identity(2));
     }
@@ -552,5 +503,25 @@ mod tests {
     #[should_panic]
     fn test_matrix_inverse_singular() {
         matrix!([4, 2], [12, 6]).invert().unwrap();
+    }
+
+    #[test]
+    fn submatrix_mut_swap_rows() {
+        let data: Vec<_> = (0u8..9).collect();
+
+        let rows: Vec<Vec<u8>> = data.chunks_exact(3).map(|chunk| chunk.to_vec()).collect();
+
+        let mut rows_rev = rows.clone();
+        rows_rev.reverse();
+        let m_rev = Matrix::<galois_8::Field>::new_with_data(&rows_rev);
+
+        let mut m = Matrix::<galois_8::Field>::new_with_data(&rows);
+
+        {
+            let mut rows_mut = m.submatrix_mut(.., ..);
+            rows_mut.swap_rows(0, 2);
+        }
+
+        assert_eq!(m, m_rev);
     }
 }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -7,6 +7,10 @@ use alloc::vec::Vec;
 use crate::Field;
 use smallvec::SmallVec;
 
+const ROW_ARRAY_STACK_LENGTH: usize = 64;
+/// Maximum length of the matrix data array in stack, exceeding which leads to heap allocation.
+const DATA_ARRAY_STACK_LENGTH: usize = 1024;
+
 #[derive(Debug)]
 pub enum Error {
     SingularMatrix,
@@ -34,8 +38,8 @@ pub fn flatten<T>(m: Vec<Vec<T>>) -> Vec<T> {
 pub struct Matrix<F: Field> {
     row_count: usize,
     col_count: usize,
-    data: SmallVec<[F::Elem; 1024]>, // store in flattened structure
-                                     // the smallvec can hold a matrix of size up to 32x32 in stack
+    /// Row-major flattened matrix cells.
+    data: SmallVec<[F::Elem; DATA_ARRAY_STACK_LENGTH]>,
 }
 
 fn calc_matrix_row_start_end(col_count: usize, row: usize) -> (usize, usize) {
@@ -45,11 +49,98 @@ fn calc_matrix_row_start_end(col_count: usize, row: usize) -> (usize, usize) {
     (start, end)
 }
 
+pub type RowRef<'a, T> = &'a [T];
+pub type RowRefArr<'a, T> = SmallVec<[RowRef<'a, T>; ROW_ARRAY_STACK_LENGTH]>;
+
+pub type RowMut<'a, T> = &'a mut [T];
+pub type RowMutArr<'a, T> = SmallVec<[RowMut<'a, T>; ROW_ARRAY_STACK_LENGTH]>;
+
+pub struct SubmatrixMut<'a, F: Field> {
+    row_count: usize,
+    col_count: usize,
+    rows: RowMutArr<'a, F::Elem>,
+}
+
+impl<'a, F: Field> SubmatrixMut<'a, F> {
+    pub fn new(row_count: usize, col_count: usize, rows: RowMutArr<'a, F::Elem>) -> Self {
+        debug_assert_eq!(rows.len(), row_count);
+        debug_assert!(rows.iter().all(|row| row.len() == col_count));
+
+        Self {
+            row_count,
+            col_count,
+            rows,
+        }
+    }
+
+    /// Write the identity matrix into the rows.
+    pub fn make_identity(&mut self) {
+        for (i, row) in self.rows.iter_mut().enumerate() {
+            for (j, a) in row.iter_mut().enumerate() {
+                *a = if i == j { F::one() } else { F::zero() }
+            }
+        }
+    }
+
+    /// Write the Vandermonde matrix into the rows.
+    pub fn make_vandermonde(&mut self) {
+        for i in 0..self.row_count {
+            let row_gen = F::exp(F::generator(), i + 1);
+            for j in 0..self.col_count {
+                let a = F::exp(row_gen, j);
+                self.rows[i][j] = a;
+            }
+        }
+    }
+
+    /// In-place Gaussian elimination.
+    pub fn gaussian_elim(&mut self) -> Result<(), Error> {
+        let n = self.row_count;
+
+        for i in 0..n {
+            // Find pivot
+            let mut pivot_row = None;
+            for r in i..n {
+                if self.rows[r][i] != F::zero() {
+                    pivot_row = Some(r);
+                    break;
+                }
+            }
+            let pivot_row = pivot_row.ok_or(Error::SingularMatrix)?;
+
+            // Swap to top
+            if pivot_row != i {
+                self.rows.swap(i, pivot_row);
+            }
+
+            // Scale pivot to 1
+            let inv_pivot = F::inv(self.rows[i][i]);
+            for a in self.rows[i].iter_mut() {
+                *a = F::mul(*a, inv_pivot);
+            }
+
+            // Eliminate other rows
+            for r in 0..n {
+                if r != i && self.rows[r][i] != F::zero() {
+                    let factor = self.rows[r][i];
+                    for j in 0..2 * n {
+                        let a = self.rows[r][j];
+                        self.rows[r][j] = F::add(a, F::mul(factor, self.rows[i][j]));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
 impl<F: Field> Matrix<F> {
     fn calc_row_start_end(&self, row: usize) -> (usize, usize) {
         calc_matrix_row_start_end(self.col_count, row)
     }
 
+    // TODO: rename to `zero`
     pub fn new(rows: usize, cols: usize) -> Matrix<F> {
         let data = SmallVec::from_vec(vec![F::zero(); rows * cols]);
 
@@ -79,10 +170,29 @@ impl<F: Field> Matrix<F> {
         }
     }
 
+    pub fn from_rows<'a>(rows: RowRefArr<'a, F::Elem>) -> Self {
+        let row_count = rows.len();
+        let col_count = rows[0].len();
+
+        let mut data: SmallVec<[F::Elem; DATA_ARRAY_STACK_LENGTH]> =
+            SmallVec::with_capacity(row_count * col_count);
+
+        for row in rows.iter() {
+            debug_assert_eq!(row.len(), col_count);
+            data.extend_from_slice(row);
+        }
+
+        Self {
+            row_count,
+            col_count,
+            data,
+        }
+    }
+
     #[cfg(test)]
     pub fn make_random(size: usize) -> Matrix<F>
     where
-        rand::distributions::Standard: rand::distributions::Distribution<F::Elem>,
+        rand::distr::StandardUniform: rand::distr::Distribution<F::Elem>,
     {
         let mut vec: Vec<Vec<F::Elem>> = vec![vec![Default::default(); size]; size];
         for v in vec.iter_mut() {
@@ -138,35 +248,111 @@ impl<F: Field> Matrix<F> {
         result
     }
 
-    pub fn augment(&self, rhs: &Matrix<F>) -> Matrix<F> {
-        if self.row_count != rhs.row_count {
-            panic!(
-                "Matrices do not have the same row count, lhs: {}, rhs: {}",
-                self.row_count, rhs.row_count
-            )
-        }
-        let mut result = Self::new(self.row_count, self.col_count + rhs.col_count);
-        for r in 0..self.row_count {
-            for c in 0..self.col_count {
-                acc!(result, r, c) = acc!(self, r, c).clone();
+    pub fn augment_with_identity(&self) -> Matrix<F> {
+        let n = self.row_count;
+        let mut aug = Matrix::new(n, 2 * n);
+
+        for i in 0..n {
+            for j in 0..n {
+                aug.set(i, j, self.get(i, j));
             }
-            let self_column_count = self.col_count;
-            for c in 0..rhs.col_count {
-                acc!(result, r, self_column_count + c) = acc!(rhs, r, c).clone();
-            }
+            aug.set(i, n + i, F::one()); // identity
         }
 
-        result
+        aug
     }
 
-    pub fn sub_matrix(&self, rmin: usize, cmin: usize, rmax: usize, cmax: usize) -> Matrix<F> {
-        let mut result = Self::new(rmax - rmin, cmax - cmin);
-        for r in rmin..rmax {
-            for c in cmin..cmax {
-                acc!(result, r - rmin, c - cmin) = acc!(self, r, c).clone();
+    pub fn submatrix<R, C>(&self, row_range: R, col_range: C) -> Self
+    where
+        R: std::ops::RangeBounds<usize>,
+        C: std::ops::RangeBounds<usize>,
+    {
+        use std::ops::Bound::*;
+
+        let row_start = match row_range.start_bound() {
+            Included(&x) => x,
+            Excluded(&x) => x + 1,
+            Unbounded => 0,
+        };
+        let row_end = match row_range.end_bound() {
+            Included(&x) => x + 1,
+            Excluded(&x) => x,
+            Unbounded => self.row_count,
+        };
+
+        let col_start = match col_range.start_bound() {
+            Included(&x) => x,
+            Excluded(&x) => x + 1,
+            Unbounded => 0,
+        };
+        let col_end = match col_range.end_bound() {
+            Included(&x) => x + 1,
+            Excluded(&x) => x,
+            Unbounded => self.col_count,
+        };
+
+        let row_count = row_end - row_start;
+        let col_count = col_end - col_start;
+
+        let mut m = Matrix::new(row_count, col_count);
+        for (r, i) in (row_start..row_end).zip(0..) {
+            for (c, j) in (col_start..col_end).zip(0..) {
+                m.set(i, j, self.get(r, c));
             }
         }
-        result
+
+        m
+    }
+
+    pub fn submatrix_mut<'a, R, C>(&'a mut self, row_range: R, col_range: C) -> SubmatrixMut<'a, F>
+    where
+        R: std::ops::RangeBounds<usize>,
+        C: std::ops::RangeBounds<usize>,
+    {
+        use std::ops::Bound::*;
+
+        let row_start = match row_range.start_bound() {
+            Included(&x) => x,
+            Excluded(&x) => x + 1,
+            Unbounded => 0,
+        };
+        let row_end = match row_range.end_bound() {
+            Included(&x) => x + 1,
+            Excluded(&x) => x,
+            Unbounded => self.row_count,
+        };
+
+        let col_start = match col_range.start_bound() {
+            Included(&x) => x,
+            Excluded(&x) => x + 1,
+            Unbounded => 0,
+        };
+        let col_end = match col_range.end_bound() {
+            Included(&x) => x + 1,
+            Excluded(&x) => x,
+            Unbounded => self.col_count,
+        };
+
+        let row_count = row_end - row_start;
+        let col_count = col_end - col_start;
+        let base_ptr = self.data.as_mut_ptr();
+
+        let rows: RowMutArr<'a, F::Elem> = (row_start..row_end)
+            .map(|i| unsafe {
+                let row_ptr = base_ptr.add(i * self.col_count + col_start);
+                std::slice::from_raw_parts_mut(row_ptr, col_count)
+            })
+            .collect();
+
+        SubmatrixMut::new(row_count, col_count, rows)
+    }
+
+    pub fn rows<'a>(&'a self) -> RowRefArr<'a, F::Elem> {
+        self.data.chunks(self.col_count).collect()
+    }
+
+    pub fn rows_mut<'a>(&'a mut self) -> RowMutArr<'a, F::Elem> {
+        self.data.chunks_mut(self.col_count).collect()
     }
 
     pub fn get_row(&self, row: usize) -> &[F::Elem] {
@@ -192,87 +378,31 @@ impl<F: Field> Matrix<F> {
         self.row_count == self.col_count
     }
 
-    pub fn gaussian_elim(&mut self) -> Result<(), Error> {
-        for r in 0..self.row_count {
-            if acc!(self, r, r) == F::zero() {
-                for r_below in r + 1..self.row_count {
-                    if acc!(self, r_below, r) != F::zero() {
-                        self.swap_rows(r, r_below);
-                        break;
-                    }
-                }
-            }
-            // If we couldn't find one, the matrix is singular.
-            if acc!(self, r, r) == F::zero() {
-                return Err(Error::SingularMatrix);
-            }
-            // Scale to 1.
-            if acc!(self, r, r) != F::one() {
-                let scale = F::div(F::one(), acc!(self, r, r).clone());
-                for c in 0..self.col_count {
-                    acc!(self, r, c) = F::mul(scale, acc!(self, r, c).clone());
-                }
-            }
-            // Make everything below the 1 be a 0 by subtracting
-            // a multiple of it.  (Subtraction and addition are
-            // both exclusive or in the Galois field.)
-            for r_below in r + 1..self.row_count {
-                if acc!(self, r_below, r) != F::zero() {
-                    let scale = acc!(self, r_below, r).clone();
-                    for c in 0..self.col_count {
-                        acc!(self, r_below, c) = F::add(
-                            acc!(self, r_below, c).clone(),
-                            F::mul(scale, acc!(self, r, c).clone()),
-                        );
-                    }
-                }
-            }
-        }
-
-        // Now clear the part above the main diagonal.
-        for d in 0..self.row_count {
-            for r_above in 0..d {
-                if acc!(self, r_above, d) != F::zero() {
-                    let scale = acc!(self, r_above, d).clone();
-                    for c in 0..self.col_count {
-                        acc!(self, r_above, c) = F::add(
-                            acc!(self, r_above, c).clone(),
-                            F::mul(scale, acc!(self, d, c).clone()),
-                        );
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-
-    pub fn invert(&self) -> Result<Matrix<F>, Error> {
+    pub fn invert<'a>(&'a self) -> Result<Matrix<F>, Error> {
         if !self.is_square() {
             panic!("Trying to invert a non-square matrix")
         }
 
-        let row_count = self.row_count;
-        let col_count = self.col_count;
-
-        let mut work = self.augment(&Self::identity(row_count));
-        work.gaussian_elim()?;
-
-        Ok(work.sub_matrix(0, row_count, col_count, col_count * 2))
-    }
-
-    pub fn vandermonde(rows: usize, cols: usize) -> Matrix<F> {
-        let mut result = Self::new(rows, cols);
-
-        for r in 0..rows {
-            // doesn't matter what `r_a` is as long as it's unique.
-            // then the vandermonde matrix is invertible.
-            let r_a = F::nth(r);
-            for c in 0..cols {
-                acc!(result, r, c) = F::exp(r_a, c);
-            }
+        let mut aug = self.augment_with_identity();
+        {
+            let mut aug_rows = aug.submatrix_mut(.., ..);
+            aug_rows.gaussian_elim()?;
         }
 
-        result
+        Ok(aug.submatrix(0..aug.row_count, aug.row_count..aug.col_count))
+    }
+
+    pub fn encode_coeffs(data_shards: usize, total_shards: usize) -> Matrix<F> {
+        let mut mat = Self::new(total_shards, data_shards);
+        {
+            let mut top_square = mat.submatrix_mut(0..data_shards, 0..data_shards);
+            top_square.make_identity();
+        }
+        {
+            let mut bottom_mat = mat.submatrix_mut(data_shards..total_shards, 0..data_shards);
+            bottom_mat.make_vandermonde();
+        }
+        mat
     }
 }
 
@@ -354,12 +484,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn test_incompatible_augment() {
-        let m1 = matrix!([0, 1]);
-        let m2 = matrix!([0, 1], [2, 3]);
+    fn test_augment_right_identity() {
+        let m1 = matrix!([0, 1], [2, 3]);
 
-        m1.augment(&m2);
+        let m2 = m1.augment_with_identity();
+        let m2_right = m2.sub_matrix(0, 2, 4, 4);
+
+        assert_eq!(m2_right, Matrix::identity(2));
     }
 
     #[test]

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -61,11 +61,11 @@ impl<'a, F: Field> SubmatrixMut<'a, F> {
     /// Write the Vandermonde matrix into the rows.
     fn make_vandermonde(&mut self) {
         for (i, row) in self.rows.iter_mut().enumerate() {
-            // FIXME: row_gen should be non-0 and unique, such as in
-            // let row_gen = F::exp(F::generator(), i + 1);
+            let row_gen = F::exp(F::generator(), i + 1);
+            // FIXME: row_gen should be non-0 and unique, such as above.
             // Below is the crate v6.0 behaviour that leads to row_gen(0) == 0
             // and the first row being all ones.
-            let row_gen = F::nth(i);
+            // let row_gen = F::nth(i);
             for (j, a) in row.iter_mut().enumerate() {
                 *a = F::exp(row_gen, j);
             }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -74,14 +74,20 @@ impl<'a, F: Field> SubmatrixMut<'a, F> {
 
     /// Swap rows in place.
     fn swap_rows(&mut self, row1: usize, row2: usize) {
-        let (first, second) = if row1 < row2 {
-            (row1, row2)
-        } else {
-            (row2, row1)
-        };
+        for j in 0..self.col_count {
+            let tmp = self.rows[row1][j];
+            self.rows[row1][j] = self.rows[row2][j];
+            self.rows[row2][j] = tmp;
+        }
 
-        let (left, right) = self.rows.split_at_mut(second);
-        left[first].swap_with_slice(right[0]);
+        // Below is an approach which may be faster for rows with hundreds of elements or more.
+        // let (first, second) = if row1 < row2 {
+        //     (row1, row2)
+        // } else {
+        //     (row2, row1)
+        // };
+        // let (left, right) = self.rows.split_at_mut(second);
+        // left[first].swap_with_slice(right[0]);
     }
 
     /// In-place Gaussian elimination.

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -49,29 +49,6 @@ impl<'a, F: Field> SubmatrixMut<'a, F> {
         }
     }
 
-    /// Write the identity matrix into the rows.
-    fn make_identity(&mut self) {
-        for (i, row) in self.rows.iter_mut().enumerate() {
-            for (j, a) in row.iter_mut().enumerate() {
-                *a = if i == j { F::one() } else { F::zero() }
-            }
-        }
-    }
-
-    /// Write the Vandermonde matrix into the rows.
-    fn make_vandermonde(&mut self) {
-        for (i, row) in self.rows.iter_mut().enumerate() {
-            let row_gen = F::exp(F::generator(), i + 1);
-            // FIXME: row_gen should be non-0 and unique, such as above.
-            // Below is the crate v6.0 behaviour that leads to row_gen(0) == 0
-            // and the first row being all ones.
-            // let row_gen = F::nth(i);
-            for (j, a) in row.iter_mut().enumerate() {
-                *a = F::exp(row_gen, j);
-            }
-        }
-    }
-
     /// Swap rows in place.
     fn swap_rows(&mut self, row1: usize, row2: usize) {
         let (first, second) = if row1 < row2 {
@@ -185,6 +162,39 @@ impl<F: Field> Matrix<F> {
         Self::new_with_data(&vec)
     }
 
+    /// Write rows `[row_offset..]` of a Vandermonde matrix into the result. Here, `row_offset`
+    /// allows to do construct submatrices of a Vandermonde matrix on which to do targeted linear
+    /// algebra.
+    fn vandermonde(row_count: usize, col_count: usize, row_offset: usize) -> Self {
+        let mut mat = Matrix::new(row_count, col_count);
+
+        for (i, row) in mat.rows_mut().iter_mut().enumerate() {
+            // let row_gen = F::exp(F::generator(), i + 1);
+            //
+            // row_gen should be non-0 and unique, such as above. Below is the crate v6.0 behaviour
+            // that only works, that is row_gen(0) != 0, because in that case row_offset ==
+            // self.col_count != 0.
+            let row_gen = F::nth(i + row_offset);
+            for (j, a) in row.iter_mut().enumerate() {
+                *a = F::exp(row_gen, j);
+            }
+        }
+
+        mat
+    }
+
+    /// Construct the systematic generator matrix $G = [I | E]$ where $E$ is the parity encoder
+    /// coefficient matrix.
+    fn systematic_generator(e: Matrix<F>) -> Self {
+        let col_count = e.col_count;
+        let mut result = Self::new(col_count + e.row_count, col_count);
+        for i in 0..col_count {
+            result.set(i, i, F::one());
+        }
+        result.data[col_count * col_count..].copy_from_slice(&e.data);
+        result
+    }
+
     #[cfg(test)]
     pub fn identity(size: usize) -> Self {
         let mut result = Self::new(size, size);
@@ -242,20 +252,19 @@ impl<F: Field> Matrix<F> {
             }
             aug.set(i, n + i, F::one()); // identity
         }
-
         aug
     }
 
     fn submatrix<R, C>(&self, row_range: R, col_range: C) -> Self
     where
-        R: std::ops::RangeBounds<usize>,
-        C: std::ops::RangeBounds<usize>,
+        R: core::ops::RangeBounds<usize>,
+        C: core::ops::RangeBounds<usize>,
     {
         let b = self.matrix_bounds(row_range, col_range);
 
         let mut m = Matrix::new(b.row_count, b.col_count);
-        for (r, i) in (b.row_start..b.row_end).zip(0..) {
-            for (c, j) in (b.col_start..b.col_end).zip(0..) {
+        for (i, r) in (b.row_start..b.row_end).enumerate() {
+            for (j, c) in (b.col_start..b.col_end).enumerate() {
                 m.set(i, j, self.get(r, c));
             }
         }
@@ -265,8 +274,8 @@ impl<F: Field> Matrix<F> {
 
     fn submatrix_mut<'a, R, C>(&'a mut self, row_range: R, col_range: C) -> SubmatrixMut<'a, F>
     where
-        R: std::ops::RangeBounds<usize>,
-        C: std::ops::RangeBounds<usize>,
+        R: core::ops::RangeBounds<usize>,
+        C: core::ops::RangeBounds<usize>,
     {
         let b = self.matrix_bounds(row_range, col_range);
         let base_ptr = self.data.as_mut_ptr();
@@ -274,7 +283,7 @@ impl<F: Field> Matrix<F> {
         let rows: RowMutArr<'a, F::Elem> = (b.row_start..b.row_end)
             .map(|i| unsafe {
                 let row_ptr = base_ptr.add(i * self.col_count + b.col_start);
-                std::slice::from_raw_parts_mut(row_ptr, b.col_count)
+                core::slice::from_raw_parts_mut(row_ptr, b.col_count)
             })
             .collect();
 
@@ -312,25 +321,23 @@ impl<F: Field> Matrix<F> {
         Ok(aug.submatrix(0..aug.row_count, aug.row_count..aug.col_count))
     }
 
+    fn parity_encode_coeffs(data_shards: usize, total_shards: usize) -> Self {
+        let v0 = Matrix::vandermonde(data_shards, data_shards, 0);
+        let v1 = Matrix::vandermonde(total_shards - data_shards, data_shards, data_shards);
+        v1.multiply(&v0.invert().unwrap())
+    }
+
     pub fn encode_coeffs(data_shards: usize, total_shards: usize) -> Self {
-        let mut mat = Self::new(total_shards, data_shards);
-        {
-            let mut top_square = mat.submatrix_mut(0..data_shards, 0..data_shards);
-            top_square.make_identity();
-        }
-        {
-            let mut bottom_mat = mat.submatrix_mut(data_shards..total_shards, 0..data_shards);
-            bottom_mat.make_vandermonde();
-        }
-        mat
+        let parity_encode_coeffs = Matrix::parity_encode_coeffs(data_shards, total_shards);
+        Matrix::systematic_generator(parity_encode_coeffs)
     }
 
     fn matrix_bounds<R, C>(&self, row_range: R, col_range: C) -> MatrixBounds
     where
-        R: std::ops::RangeBounds<usize>,
-        C: std::ops::RangeBounds<usize>,
+        R: core::ops::RangeBounds<usize>,
+        C: core::ops::RangeBounds<usize>,
     {
-        use std::ops::Bound::*;
+        use core::ops::Bound::*;
 
         let row_start = match row_range.start_bound() {
             Included(&x) => x,
@@ -368,6 +375,7 @@ impl<F: Field> Matrix<F> {
     }
 }
 
+#[derive(Copy, Clone, Debug)]
 struct MatrixBounds {
     row_count: usize,
     col_count: usize,

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -74,20 +74,14 @@ impl<'a, F: Field> SubmatrixMut<'a, F> {
 
     /// Swap rows in place.
     fn swap_rows(&mut self, row1: usize, row2: usize) {
-        for j in 0..self.col_count {
-            let tmp = self.rows[row1][j];
-            self.rows[row1][j] = self.rows[row2][j];
-            self.rows[row2][j] = tmp;
-        }
+        let (first, second) = if row1 < row2 {
+            (row1, row2)
+        } else {
+            (row2, row1)
+        };
 
-        // Below is an approach which may be faster for rows with hundreds of elements or more.
-        // let (first, second) = if row1 < row2 {
-        //     (row1, row2)
-        // } else {
-        //     (row2, row1)
-        // };
-        // let (left, right) = self.rows.split_at_mut(second);
-        // left[first].swap_with_slice(right[0]);
+        let (left, right) = self.rows.split_at_mut(second);
+        left[first].swap_with_slice(right[0]);
     }
 
     /// In-place Gaussian elimination.

--- a/src/tests/galois_16.rs
+++ b/src/tests/galois_16.rs
@@ -48,10 +48,10 @@ quickcheck! {
 
         let mut corrupt_pos_s = Vec::with_capacity(corrupt);
         for _ in 0..corrupt {
-            let mut pos = rand::random::<usize>() % (data + parity);
+            let mut pos: usize = rand::random::<u64>() as usize % (data + parity);
 
             while let Some(_) = corrupt_pos_s.iter().find(|&&x| x == pos) {
-                pos = rand::random::<usize>() % (data + parity);
+                pos = rand::random::<u64>() as usize % (data + parity);
             }
 
             corrupt_pos_s.push(pos);
@@ -123,10 +123,10 @@ quickcheck! {
 
         let mut corrupt_pos_s = Vec::with_capacity(corrupt);
         for _ in 0..corrupt {
-            let mut pos = rand::random::<usize>() % (data + parity);
+            let mut pos = rand::random::<u64>() as usize % (data + parity);
 
             while let Some(_) = corrupt_pos_s.iter().find(|&&x| x == pos) {
-                pos = rand::random::<usize>() % (data + parity);
+                pos = rand::random::<u64>() as usize % (data + parity);
             }
 
             corrupt_pos_s.push(pos);
@@ -172,10 +172,10 @@ quickcheck! {
 
         let mut corrupt_pos_s = Vec::with_capacity(corrupt);
         for _ in 0..corrupt {
-            let mut pos = rand::random::<usize>() % (data + parity);
+            let mut pos = rand::random::<u64>() as usize % (data + parity);
 
             while let Some(_) = corrupt_pos_s.iter().find(|&&x| x == pos) {
-                pos = rand::random::<usize>() % (data + parity);
+                pos = rand::random::<u64>() as usize % (data + parity);
             }
 
             corrupt_pos_s.push(pos);
@@ -235,10 +235,10 @@ quickcheck! {
 
         let mut corrupt_pos_s = Vec::with_capacity(corrupt);
         for _ in 0..corrupt {
-            let mut pos = rand::random::<usize>() % (data + parity);
+            let mut pos = rand::random::<u64>() as usize % (data + parity);
 
             while let Some(_) = corrupt_pos_s.iter().find(|&&x| x == pos) {
-                pos = rand::random::<usize>() % (data + parity);
+                pos = rand::random::<u64>() as usize % (data + parity);
             }
 
             corrupt_pos_s.push(pos);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -6,7 +6,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use super::{Error, SBSError, galois_8};
-use rand::{self, Rng, thread_rng};
+use rand::{self, Rng, rng};
 
 mod galois_16;
 
@@ -117,10 +117,10 @@ fn test_too_many_shards() {
 
 #[test]
 fn test_shard_count() {
-    let mut rng = thread_rng();
+    let mut rng = rng();
     for _ in 0..10 {
-        let data_shard_count = rng.gen_range(1, 128);
-        let parity_shard_count = rng.gen_range(1, 128);
+        let data_shard_count = rng.random_range(1..128);
+        let parity_shard_count = rng.random_range(1..128);
 
         let total_shard_count = data_shard_count + parity_shard_count;
 
@@ -367,10 +367,10 @@ quickcheck! {
 
         let mut corrupt_pos_s = Vec::with_capacity(corrupt);
         for _ in 0..corrupt {
-            let mut pos = rand::random::<usize>() % (data + parity);
+            let mut pos: usize = rand::random::<u64>() as usize % (data + parity);
 
             while let Some(_) = corrupt_pos_s.iter().find(|&&x| x == pos) {
-                pos = rand::random::<usize>() % (data + parity);
+                pos = rand::random::<u64>() as usize % (data + parity);
             }
 
             corrupt_pos_s.push(pos);
@@ -442,10 +442,10 @@ quickcheck! {
 
         let mut corrupt_pos_s = Vec::with_capacity(corrupt);
         for _ in 0..corrupt {
-            let mut pos = rand::random::<usize>() % (data + parity);
+            let mut pos = rand::random::<u64>() as usize % (data + parity);
 
             while let Some(_) = corrupt_pos_s.iter().find(|&&x| x == pos) {
-                pos = rand::random::<usize>() % (data + parity);
+                pos = rand::random::<u64>() as usize % (data + parity);
             }
 
             corrupt_pos_s.push(pos);
@@ -491,10 +491,10 @@ quickcheck! {
 
         let mut corrupt_pos_s = Vec::with_capacity(corrupt);
         for _ in 0..corrupt {
-            let mut pos = rand::random::<usize>() % (data + parity);
+            let mut pos = rand::random::<u64>() as usize % (data + parity);
 
             while let Some(_) = corrupt_pos_s.iter().find(|&&x| x == pos) {
-                pos = rand::random::<usize>() % (data + parity);
+                pos = rand::random::<u64>() as usize % (data + parity);
             }
 
             corrupt_pos_s.push(pos);
@@ -554,10 +554,10 @@ quickcheck! {
 
         let mut corrupt_pos_s = Vec::with_capacity(corrupt);
         for _ in 0..corrupt {
-            let mut pos = rand::random::<usize>() % (data + parity);
+            let mut pos = rand::random::<u64>() as usize % (data + parity);
 
             while let Some(_) = corrupt_pos_s.iter().find(|&&x| x == pos) {
-                pos = rand::random::<usize>() % (data + parity);
+                pos = rand::random::<u64>() as usize % (data + parity);
             }
 
             corrupt_pos_s.push(pos);
@@ -763,8 +763,8 @@ quickcheck! {
             let mut parity_refs =
                 convert_2D_slices!(parity_shards =>to_mut_vec &mut [u8]);
 
-            for i in 0..data {
-                r.encode_single_sep(i, data_refs[i], &mut parity_refs).unwrap();
+            for (i, d) in data_refs.iter().enumerate() {
+                r.encode_single_sep(i, d, &mut parity_refs).unwrap();
             }
         }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -5,8 +5,8 @@ extern crate alloc;
 use alloc::vec;
 use alloc::vec::Vec;
 
-use super::{galois_8, Error, SBSError};
-use rand::{self, thread_rng, Rng};
+use super::{Error, SBSError, galois_8};
+use rand::{self, Rng, thread_rng};
 
 mod galois_16;
 
@@ -41,7 +41,7 @@ where
 
 pub fn fill_random<T>(arr: &mut [T])
 where
-    rand::distributions::Standard: rand::distributions::Distribution<T>,
+    rand::distr::StandardUniform: rand::distr::Distribution<T>,
 {
     for a in arr.iter_mut() {
         *a = rand::random::<T>();
@@ -1019,9 +1019,10 @@ fn test_verify_with_buffer_gives_correct_parity_shards() {
 
                 let mut buffer_refs = convert_2D_slices!(buffer =>to_mut_vec &mut [u8]);
 
-                assert!(!r
-                    .verify_with_buffer(&slice_copy_refs, &mut buffer_refs)
-                    .unwrap());
+                assert!(
+                    !r.verify_with_buffer(&slice_copy_refs, &mut buffer_refs)
+                        .unwrap()
+                );
             }
 
             for a in 0..3 {


### PR DESCRIPTION
## Functional changes

- Replaced a redundant computation M · 1/M in `ReedSolomon::new` with the identity matrix when the encoder matrix is constructed.
- Pruned and streamlined ReedSolomon::reconstruct leading to reconstruct benchmark improvement.
- Swapped row-column accesses during coefficient application in ReedSolomon::code_some_slices to improve cache locality and to reduce the number of conditional jumps.
- Simplified the implementation of Gaussian elimination while maintaining functional equivalence.
- Within Gaussian elimination, used an asymptotically faster safe Rust primitive for row swapping.

## Interface changes

- Crate dependencies have been updated.
- Some previously `pub` functions in `matrix.rs` are made private because they are not used outside of that module.