### PR TITLE
Speedup

### DIFF
--- a/benches/bandwidth.rs
+++ b/benches/bandwidth.rs
@@ -189,5 +189,11 @@ fn reconstruct_none(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, encode, reconstruct_one, reconstruct_all, reconstruct_none);
+criterion_group!(
+    benches,
+    encode,
+    reconstruct_one,
+    reconstruct_all,
+    reconstruct_none
+);
 criterion_main!(benches);

--- a/build.rs
+++ b/build.rs
@@ -173,9 +173,11 @@ fn compile_simd_c() {
         Err(_error) => {
             // On x86-64 enabling Haswell architecture unlocks useful instructions and improves performance
             // dramatically while allowing it to run ony modern CPU.
-            match env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str(){
-                "x86_64"  => { build.flag(&"-march=haswell"); },
-                _         => ()
+            match env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str() {
+                "x86_64" => {
+                    build.flag(&"-march=haswell");
+                }
+                _ => (),
             }
         }
     }

--- a/build.rs
+++ b/build.rs
@@ -158,6 +158,10 @@ fn write_tables() {
     not(any(target_os = "android", target_os = "ios"))
 ))]
 fn compile_simd_c() {
+    println!("cargo:rerun-if-changed=simd_c/reedsolomon.c");
+    println!("cargo:rerun-if-changed=simd_c/reedsolomon.h");
+    println!("cargo:rerun-if-env-changed=RUST_REED_SOLOMON_ERASURE_ARCH");
+
     let mut build = cc::Build::new();
     build.opt_level(3);
 

--- a/simd_c/reedsolomon.c
+++ b/simd_c/reedsolomon.c
@@ -63,7 +63,7 @@
 #endif
 
 
-#if defined(__AVX512F__) && __AVX512F__
+#if defined(__AVX512F__) && __AVX512F__ && defined(__AVX512BW__) && __AVX512BW__
 # define USE_AVX512 1
 # undef VECTOR_SIZE
 # define VECTOR_SIZE 64
@@ -534,10 +534,24 @@ static ALWAYS_INLINE PROTO_RETURN reedsolomon_gal_mul_impl(
 # define STORE(addr, vec) storeu_v(addr, vec)
 #endif
 
-#if RS_HAVE_CLANG_LOOP_UNROLL
-# pragma clang loop unroll(enable)
-#endif
-        for(size_t x = 0; x < len / sizeof(v); x++) {
+        const size_t unroll = 4 * sizeof(v);
+        for (; done + unroll <= len; done += unroll) {
+                for (size_t i = 0; i < 4; i++) {
+                        const size_t offset = done + i * sizeof(v);
+                        const v in_x = LOAD(&in[offset]),
+                                old = LOAD(&out[offset]),
+                                result = reedsolomon_gal_mul_v(
+                                                low_mask_unpacked,
+                                                low_vector, high_vector,
+                                                modifier,
+                                                in_x,
+                                                old);
+
+                        STORE(&out[offset], result);
+                }
+        }
+
+        for (; done + sizeof(v) <= len; done += sizeof(v)) {
                 const v in_x = LOAD(&in[done]),
                         old = LOAD(&out[done]),
                         result = reedsolomon_gal_mul_v(
@@ -548,8 +562,6 @@ static ALWAYS_INLINE PROTO_RETURN reedsolomon_gal_mul_impl(
                                         old);
 
                 STORE(&out[done], result);
-
-                done += sizeof(v);
         }
 
         return done;
@@ -571,4 +583,325 @@ HOT_FUNCTION
 #endif
 FORCE_ALIGN_ARG_POINTER PROTO(reedsolomon_gal_mul_xor) {
         return reedsolomon_gal_mul_impl(low, high, in, out, len, xor_v);
+}
+
+static __attribute__((noinline)) size_t reedsolomon_gal_mul_row_from(
+        const uint8_t *const *restrict inputs,
+        const uint8_t *restrict coefficients,
+        const uint8_t *restrict low_tables,
+        const uint8_t *restrict high_tables,
+        const size_t input_count,
+        uint8_t *restrict const out,
+        const size_t start,
+        const size_t len) {
+        if (input_count == 0) {
+                return start;
+        }
+
+        const v low_mask_unpacked = set1_epi8_v(0x0f);
+        const size_t bytes_done = len - (len - start) % sizeof(v);
+        size_t input = 0;
+
+        for (; input + 1 < input_count; input += 2) {
+                size_t table_offset = (size_t)coefficients[input] * 16;
+                const v low0 =
+                        replicate_v128_v(loadu_v128(&low_tables[table_offset]));
+                const v high0 =
+                        replicate_v128_v(loadu_v128(&high_tables[table_offset]));
+                table_offset = (size_t)coefficients[input + 1] * 16;
+                const v low1 =
+                        replicate_v128_v(loadu_v128(&low_tables[table_offset]));
+                const v high1 =
+                        replicate_v128_v(loadu_v128(&high_tables[table_offset]));
+
+                for (size_t done = start; done < bytes_done; done += sizeof(v)) {
+                        const v in0 = loadu_v(&inputs[input][done]);
+                        const v low_input0 = and_v(in0, low_mask_unpacked);
+                        const v high_input0 =
+                                and_v(srli_epi64_v(in0), low_mask_unpacked);
+                        v sum = xor_v(
+                                shuffle_epi8_v(low0, low_input0),
+                                shuffle_epi8_v(high0, high_input0));
+
+                        const v in1 = loadu_v(&inputs[input + 1][done]);
+                        const v low_input1 = and_v(in1, low_mask_unpacked);
+                        const v high_input1 =
+                                and_v(srli_epi64_v(in1), low_mask_unpacked);
+                        sum = xor_v(sum, xor_v(
+                                shuffle_epi8_v(low1, low_input1),
+                                shuffle_epi8_v(high1, high_input1)));
+
+                        if (input != 0) {
+                                sum = xor_v(sum, loadu_v(&out[done]));
+                        }
+                        storeu_v(&out[done], sum);
+                }
+        }
+
+        if (input < input_count) {
+                const size_t table_offset = (size_t)coefficients[input] * 16;
+                if (input == 0) {
+                        reedsolomon_gal_mul_impl(
+                                &low_tables[table_offset],
+                                &high_tables[table_offset],
+                                inputs[input] + start,
+                                out + start,
+                                len - start,
+                                noop);
+                } else {
+                        reedsolomon_gal_mul_impl(
+                                &low_tables[table_offset],
+                                &high_tables[table_offset],
+                                inputs[input] + start,
+                                out + start,
+                                len - start,
+                                xor_v);
+                }
+        }
+
+        return bytes_done;
+}
+
+#ifdef HOT
+HOT_FUNCTION
+#endif
+FORCE_ALIGN_ARG_POINTER PROTO_MATRIX(reedsolomon_gal_mul_matrix) {
+        const v low_mask_unpacked = set1_epi8_v(0x0f);
+        size_t bytes_done = len - len % sizeof(v);
+        size_t output = 0;
+
+        for (; output + 3 < output_count && len < 2048; output += 4) {
+                const uint8_t *coefficients0 = coefficient_rows[output];
+                const uint8_t *coefficients1 = coefficient_rows[output + 1];
+                const uint8_t *coefficients2 = coefficient_rows[output + 2];
+                const uint8_t *coefficients3 = coefficient_rows[output + 3];
+                size_t done = 0;
+
+                for (; done + 2 * sizeof(v) <= len; done += 2 * sizeof(v)) {
+                        v sum00 = { 0 };
+                        v sum01 = { 0 };
+                        v sum10 = { 0 };
+                        v sum11 = { 0 };
+                        v sum20 = { 0 };
+                        v sum21 = { 0 };
+                        v sum30 = { 0 };
+                        v sum31 = { 0 };
+
+                        for (size_t input = 0; input < input_count; input++) {
+                                const v in0 = loadu_v(&inputs[input][done]);
+                                const v in1 =
+                                        loadu_v(&inputs[input][done + sizeof(v)]);
+                                const v low_input0 =
+                                        and_v(in0, low_mask_unpacked);
+                                const v high_input0 =
+                                        and_v(srli_epi64_v(in0), low_mask_unpacked);
+                                const v low_input1 =
+                                        and_v(in1, low_mask_unpacked);
+                                const v high_input1 =
+                                        and_v(srli_epi64_v(in1), low_mask_unpacked);
+
+#define ACCUMULATE_ROW(coefficients, sum0, sum1) do {                    \
+                                        const size_t table_offset =      \
+                                                (size_t)(coefficients)[input] * 16; \
+                                        const v low = replicate_v128_v(  \
+                                                loadu_v128(&low_tables[table_offset])); \
+                                        const v high = replicate_v128_v( \
+                                                loadu_v128(&high_tables[table_offset])); \
+                                        sum0 = xor_v(                    \
+                                                sum0,                    \
+                                                shuffle_epi8_v(low, low_input0)); \
+                                        sum1 = xor_v(                    \
+                                                sum1,                    \
+                                                shuffle_epi8_v(low, low_input1)); \
+                                        AVX2_REGISTER_BARRIER(sum0);     \
+                                        AVX2_REGISTER_BARRIER(sum1);     \
+                                        sum0 = xor_v(                    \
+                                                sum0,                    \
+                                                shuffle_epi8_v(high, high_input0)); \
+                                        sum1 = xor_v(                    \
+                                                sum1,                    \
+                                                shuffle_epi8_v(high, high_input1)); \
+                                } while (0)
+
+#if USE_AVX2 && !USE_AVX512
+#define AVX2_REGISTER_BARRIER(sum) \
+                                __asm__ __volatile__("" : "+x"((sum).m256i))
+#else
+#define AVX2_REGISTER_BARRIER(sum) do { } while (0)
+#endif
+
+                                ACCUMULATE_ROW(coefficients0, sum00, sum01);
+                                ACCUMULATE_ROW(coefficients1, sum10, sum11);
+                                ACCUMULATE_ROW(coefficients2, sum20, sum21);
+                                ACCUMULATE_ROW(coefficients3, sum30, sum31);
+#undef AVX2_REGISTER_BARRIER
+#undef ACCUMULATE_ROW
+                        }
+
+                        storeu_v(&outputs[output][done], sum00);
+                        storeu_v(&outputs[output][done + sizeof(v)], sum01);
+                        storeu_v(&outputs[output + 1][done], sum10);
+                        storeu_v(&outputs[output + 1][done + sizeof(v)], sum11);
+                        storeu_v(&outputs[output + 2][done], sum20);
+                        storeu_v(&outputs[output + 2][done + sizeof(v)], sum21);
+                        storeu_v(&outputs[output + 3][done], sum30);
+                        storeu_v(&outputs[output + 3][done + sizeof(v)], sum31);
+                }
+
+                if (done < bytes_done) {
+                        reedsolomon_gal_mul_row_from(
+                                inputs,
+                                coefficients0,
+                                low_tables,
+                                high_tables,
+                                input_count,
+                                outputs[output],
+                                done,
+                                len);
+                        reedsolomon_gal_mul_row_from(
+                                inputs,
+                                coefficients1,
+                                low_tables,
+                                high_tables,
+                                input_count,
+                                outputs[output + 1],
+                                done,
+                                len);
+                        reedsolomon_gal_mul_row_from(
+                                inputs,
+                                coefficients2,
+                                low_tables,
+                                high_tables,
+                                input_count,
+                                outputs[output + 2],
+                                done,
+                                len);
+                        reedsolomon_gal_mul_row_from(
+                                inputs,
+                                coefficients3,
+                                low_tables,
+                                high_tables,
+                                input_count,
+                                outputs[output + 3],
+                                done,
+                                len);
+                }
+        }
+
+        for (; output + 1 < output_count; output += 2) {
+                const uint8_t *coefficients0 = coefficient_rows[output];
+                const uint8_t *coefficients1 = coefficient_rows[output + 1];
+                size_t input = 0;
+
+                for (; input + 1 < input_count; input += 2) {
+                        size_t table_offset = (size_t)coefficients0[input] * 16;
+                        const v low00 =
+                                replicate_v128_v(loadu_v128(&low_tables[table_offset]));
+                        const v high00 =
+                                replicate_v128_v(loadu_v128(&high_tables[table_offset]));
+                        table_offset = (size_t)coefficients1[input] * 16;
+                        const v low10 =
+                                replicate_v128_v(loadu_v128(&low_tables[table_offset]));
+                        const v high10 =
+                                replicate_v128_v(loadu_v128(&high_tables[table_offset]));
+                        table_offset = (size_t)coefficients0[input + 1] * 16;
+                        const v low01 =
+                                replicate_v128_v(loadu_v128(&low_tables[table_offset]));
+                        const v high01 =
+                                replicate_v128_v(loadu_v128(&high_tables[table_offset]));
+                        table_offset = (size_t)coefficients1[input + 1] * 16;
+                        const v low11 =
+                                replicate_v128_v(loadu_v128(&low_tables[table_offset]));
+                        const v high11 =
+                                replicate_v128_v(loadu_v128(&high_tables[table_offset]));
+
+                        for (size_t done = 0; done < bytes_done; done += sizeof(v)) {
+                                const v in0 = loadu_v(&inputs[input][done]);
+                                const v low_input0 = and_v(in0, low_mask_unpacked);
+                                const v high_input0 =
+                                        and_v(srli_epi64_v(in0), low_mask_unpacked);
+                                v sum0 = xor_v(
+                                        shuffle_epi8_v(low00, low_input0),
+                                        shuffle_epi8_v(high00, high_input0));
+                                v sum1 = xor_v(
+                                        shuffle_epi8_v(low10, low_input0),
+                                        shuffle_epi8_v(high10, high_input0));
+
+                                const v in1 = loadu_v(&inputs[input + 1][done]);
+                                const v low_input1 = and_v(in1, low_mask_unpacked);
+                                const v high_input1 =
+                                        and_v(srli_epi64_v(in1), low_mask_unpacked);
+                                sum0 = xor_v(sum0, xor_v(
+                                        shuffle_epi8_v(low01, low_input1),
+                                        shuffle_epi8_v(high01, high_input1)));
+                                sum1 = xor_v(sum1, xor_v(
+                                        shuffle_epi8_v(low11, low_input1),
+                                        shuffle_epi8_v(high11, high_input1)));
+
+                                if (input != 0) {
+                                        sum0 = xor_v(
+                                                sum0,
+                                                loadu_v(&outputs[output][done]));
+                                        sum1 = xor_v(
+                                                sum1,
+                                                loadu_v(&outputs[output + 1][done]));
+                                }
+
+                                storeu_v(&outputs[output][done], sum0);
+                                storeu_v(&outputs[output + 1][done], sum1);
+                        }
+                }
+
+                if (input < input_count) {
+                        size_t table_offset = (size_t)coefficients0[input] * 16;
+                        const v low0 =
+                                replicate_v128_v(loadu_v128(&low_tables[table_offset]));
+                        const v high0 =
+                                replicate_v128_v(loadu_v128(&high_tables[table_offset]));
+                        table_offset = (size_t)coefficients1[input] * 16;
+                        const v low1 =
+                                replicate_v128_v(loadu_v128(&low_tables[table_offset]));
+                        const v high1 =
+                                replicate_v128_v(loadu_v128(&high_tables[table_offset]));
+
+                        for (size_t done = 0; done < bytes_done; done += sizeof(v)) {
+                                const v in_x = loadu_v(&inputs[input][done]);
+                                const v low_input = and_v(in_x, low_mask_unpacked);
+                                const v high_input =
+                                        and_v(srli_epi64_v(in_x), low_mask_unpacked);
+                                v sum0 = xor_v(
+                                        shuffle_epi8_v(low0, low_input),
+                                        shuffle_epi8_v(high0, high_input));
+                                v sum1 = xor_v(
+                                        shuffle_epi8_v(low1, low_input),
+                                        shuffle_epi8_v(high1, high_input));
+
+                                if (input != 0) {
+                                        sum0 = xor_v(
+                                                sum0,
+                                                loadu_v(&outputs[output][done]));
+                                        sum1 = xor_v(
+                                                sum1,
+                                                loadu_v(&outputs[output + 1][done]));
+                                }
+
+                                storeu_v(&outputs[output][done], sum0);
+                                storeu_v(&outputs[output + 1][done], sum1);
+                        }
+                }
+        }
+
+        if (output < output_count) {
+                reedsolomon_gal_mul_row_from(
+                        inputs,
+                        coefficient_rows[output],
+                        low_tables,
+                        high_tables,
+                        input_count,
+                        outputs[output],
+                        0,
+                        len);
+        }
+
+        return bytes_done;
 }

--- a/simd_c/reedsolomon.h
+++ b/simd_c/reedsolomon.h
@@ -41,6 +41,21 @@
 PROTO(reedsolomon_gal_mul);
 PROTO(reedsolomon_gal_mul_xor);
 
+#define PROTO_MATRIX_ARGS                                \
+        const uint8_t *const *restrict inputs,           \
+        const uint8_t *const *restrict coefficient_rows, \
+        const uint8_t *restrict low_tables,              \
+        const uint8_t *restrict high_tables,             \
+        const size_t input_count,                        \
+        uint8_t *const *restrict outputs,                 \
+        const size_t output_count,                       \
+        const size_t len
+#define PROTO_MATRIX(name)               \
+        PROTO_RETURN                     \
+        name (PROTO_MATRIX_ARGS)
+
+PROTO_MATRIX(reedsolomon_gal_mul_matrix);
+
 typedef enum {
         REEDSOLOMON_CPU_GENERIC = 0,
         REEDSOLOMON_CPU_SSE2 = 1,

--- a/src/core.rs
+++ b/src/core.rs
@@ -346,6 +346,7 @@ pub struct ReedSolomon<F: Field> {
     parity_shard_count: usize,
     total_shard_count: usize,
     matrix: Matrix<F>,
+    single_data_decode_rows: Matrix<F>,
     data_decode_matrix_cache: Mutex<LruCache<Vec<usize>, Arc<Matrix<F>>>>,
 }
 
@@ -435,6 +436,31 @@ impl<F: Field> ReedSolomon<F> {
         vandermonde.multiply(&top.invert().unwrap())
     }
 
+    fn build_single_data_decode_rows(matrix: &Matrix<F>, data_shards: usize) -> Matrix<F> {
+        let mut rows = Matrix::new(data_shards, data_shards);
+        let parity_row = data_shards;
+
+        for missing in 0..data_shards {
+            let divisor = matrix.get(parity_row, missing);
+            let mut column = 0;
+
+            for data in 0..data_shards {
+                if data != missing {
+                    rows.set(
+                        missing,
+                        column,
+                        F::div(matrix.get(parity_row, data), divisor),
+                    );
+                    column += 1;
+                }
+            }
+
+            rows.set(missing, column, F::div(F::one(), divisor));
+        }
+
+        rows
+    }
+
     /// Creates a new instance of Reed-Solomon erasure code encoder/decoder.
     ///
     /// Returns `Error::TooFewDataShards` if `data_shards == 0`.
@@ -456,12 +482,15 @@ impl<F: Field> ReedSolomon<F> {
         let total_shards = data_shards + parity_shards;
 
         let matrix = Self::build_matrix(data_shards, total_shards);
+        let single_data_decode_rows =
+            Self::build_single_data_decode_rows(&matrix, data_shards);
 
         Ok(ReedSolomon {
             data_shard_count: data_shards,
             parity_shard_count: parity_shards,
             total_shard_count: total_shards,
             matrix,
+            single_data_decode_rows,
             data_decode_matrix_cache: Mutex::new(LruCache::new(DATA_DECODE_MATRIX_CACHE_CAPACITY)),
         })
     }
@@ -484,9 +513,7 @@ impl<F: Field> ReedSolomon<F> {
         inputs: &[T],
         outputs: &mut [U],
     ) {
-        for i_input in 0..self.data_shard_count {
-            self.code_single_slice(matrix_rows, i_input, inputs[i_input].as_ref(), outputs);
-        }
+        F::mul_slices(matrix_rows, inputs, outputs);
     }
 
     fn code_single_slice<U: AsMut<[F::Elem]>>(
@@ -694,11 +721,7 @@ impl<F: Field> ReedSolomon<F> {
         self.reconstruct_internal(slices, true)
     }
 
-    fn get_data_decode_matrix(
-        &self,
-        valid_indices: &[usize],
-        invalid_indices: &[usize],
-    ) -> Arc<Matrix<F>> {
+    fn get_data_decode_matrix(&self, invalid_indices: &[usize]) -> Arc<Matrix<F>> {
         {
             let mut cache = self.data_decode_matrix_cache.lock();
             if let Some(entry) = cache.get(invalid_indices) {
@@ -709,11 +732,26 @@ impl<F: Field> ReedSolomon<F> {
         // we have and build a square matrix. This matrix could be used to
         // generate the shards that we have from the original data.
         let mut sub_matrix = Matrix::new(self.data_shard_count, self.data_shard_count);
-        for (sub_matrix_row, &valid_index) in valid_indices.iter().enumerate() {
+        let mut invalid_pos = 0;
+        let mut sub_matrix_row = 0;
+
+        for valid_index in 0..self.total_shard_count {
+            if invalid_indices.get(invalid_pos) == Some(&valid_index) {
+                invalid_pos += 1;
+                continue;
+            }
+
             for c in 0..self.data_shard_count {
                 sub_matrix.set(sub_matrix_row, c, self.matrix.get(valid_index, c));
             }
+
+            sub_matrix_row += 1;
+            if sub_matrix_row == self.data_shard_count {
+                break;
+            }
         }
+        debug_assert_eq!(sub_matrix_row, self.data_shard_count);
+
         // Invert the matrix, so we can go from the encoded shards back to the
         // original data. Then pull out the row that generates the shard that
         // we want to decode. Note that since this matrix maps back to the
@@ -738,6 +776,29 @@ impl<F: Field> ReedSolomon<F> {
         check_piece_count!(all => self, shards);
 
         let data_shard_count = self.data_shard_count;
+
+        if let Some(first_len) = shards[0].len() {
+            if first_len == 0 {
+                return Err(Error::EmptyShard);
+            }
+
+            let mut all_present = true;
+            for shard in &shards[1..] {
+                match shard.len() {
+                    Some(len) if len == first_len => {}
+                    Some(0) => return Err(Error::EmptyShard),
+                    Some(_) => return Err(Error::IncorrectShardSize),
+                    None => {
+                        all_present = false;
+                        break;
+                    }
+                }
+            }
+
+            if all_present {
+                return Ok(());
+            }
+        }
 
         // Quick check: are all of the shards present?  If so, there's
         // nothing to do.
@@ -772,6 +833,76 @@ impl<F: Field> ReedSolomon<F> {
         }
 
         let shard_len = shard_len.expect("at least one shard present; qed");
+        self.reconstruct_missing(shards, data_only, number_present, shard_len)
+    }
+
+    #[inline(never)]
+    fn reconstruct_data_prefix<T: ReconstructShard<F>>(
+        &self,
+        shards: &mut [T],
+        missing_count: usize,
+        shard_len: usize,
+    ) -> Result<(), Error> {
+        debug_assert!(missing_count > 0);
+        debug_assert!(missing_count <= self.parity_shard_count);
+
+        let (missing_shards, available_shards) = shards.split_at_mut(missing_count);
+        let mut missing_slices: SmallVec<[&mut [F::Elem]; 32]> =
+            SmallVec::with_capacity(missing_count);
+        for shard in missing_shards {
+            match shard.get_or_initialize(shard_len) {
+                Err(Ok(shard)) => missing_slices.push(shard),
+                Err(Err(error)) => return Err(error),
+                Ok(_) => unreachable!("prefix shard was already present"),
+            }
+        }
+
+        let mut sub_shards: SmallVec<[&[F::Elem]; 32]> =
+            SmallVec::with_capacity(self.data_shard_count);
+        for shard in available_shards.iter_mut().take(self.data_shard_count) {
+            sub_shards.push(shard.get().expect("non-prefix shard is present; qed"));
+        }
+
+        if missing_count == 1 {
+            let matrix_rows = [self.single_data_decode_rows.get_row(0)];
+            self.code_some_slices(&matrix_rows, &sub_shards, &mut missing_slices);
+        } else {
+            let invalid_indices: SmallVec<[usize; 32]> = (0..missing_count).collect();
+            let data_decode_matrix = self.get_data_decode_matrix(&invalid_indices);
+            let mut matrix_rows: SmallVec<[&[F::Elem]; 32]> =
+                SmallVec::with_capacity(missing_count);
+            for missing in 0..missing_count {
+                matrix_rows.push(data_decode_matrix.get_row(missing));
+            }
+            self.code_some_slices(&matrix_rows, &sub_shards, &mut missing_slices);
+        }
+
+        Ok(())
+    }
+
+    #[inline(never)]
+    fn reconstruct_missing<T: ReconstructShard<F>>(
+        &self,
+        shards: &mut [T],
+        data_only: bool,
+        number_present: usize,
+        shard_len: usize,
+    ) -> Result<(), Error> {
+        let data_shard_count = self.data_shard_count;
+        let number_missing = self.total_shard_count - number_present;
+        if number_missing <= data_shard_count
+            && shards[..number_missing]
+                .iter()
+                .all(|shard| shard.len().is_none())
+        {
+            return self.reconstruct_data_prefix(shards, number_missing, shard_len);
+        }
+
+        let number_missing_data = shards[..data_shard_count]
+            .iter()
+            .filter(|shard| shard.len().is_none())
+            .count();
+        let number_missing_parity = number_missing - number_missing_data;
 
         // Pull out an array holding just the shards that
         // correspond to the rows of the submatrix.  These shards
@@ -791,11 +922,10 @@ impl<F: Field> ReedSolomon<F> {
         // `self.matrix`.
         let mut sub_shards: SmallVec<[&[F::Elem]; 32]> = SmallVec::with_capacity(data_shard_count);
         let mut missing_data_slices: SmallVec<[&mut [F::Elem]; 32]> =
-            SmallVec::with_capacity(self.parity_shard_count);
+            SmallVec::with_capacity(number_missing_data);
         let mut missing_parity_slices: SmallVec<[&mut [F::Elem]; 32]> =
-            SmallVec::with_capacity(self.parity_shard_count);
-        let mut valid_indices: SmallVec<[usize; 32]> = SmallVec::with_capacity(data_shard_count);
-        let mut invalid_indices: SmallVec<[usize; 32]> = SmallVec::with_capacity(data_shard_count);
+            SmallVec::with_capacity(if data_only { 0 } else { number_missing_parity });
+        let mut invalid_indices: SmallVec<[usize; 32]> = SmallVec::with_capacity(number_missing);
 
         // Separate the shards into groups
         for (matrix_row, shard) in shards.iter_mut().enumerate() {
@@ -812,7 +942,6 @@ impl<F: Field> ReedSolomon<F> {
                 Ok(shard) => {
                     if sub_shards.len() < data_shard_count {
                         sub_shards.push(shard);
-                        valid_indices.push(matrix_row);
                     } else {
                         // Already have enough shards in `sub_shards`
                         // as we only need N shards, where N = `data_shard_count`,
@@ -840,7 +969,12 @@ impl<F: Field> ReedSolomon<F> {
             }
         }
 
-        let data_decode_matrix = self.get_data_decode_matrix(&valid_indices, &invalid_indices);
+        let single_missing_data = number_missing == 1 && number_missing_data == 1;
+        let data_decode_matrix = if number_missing_data == 0 || single_missing_data {
+            None
+        } else {
+            Some(self.get_data_decode_matrix(&invalid_indices))
+        };
 
         // Re-create any data shards that were missing.
         //
@@ -848,19 +982,22 @@ impl<F: Field> ReedSolomon<F> {
         // have, and the output is the missing data shards. The computation
         // is done using the special decode matrix we just built.
         let mut matrix_rows: SmallVec<[&[F::Elem]; 32]> =
-            SmallVec::with_capacity(self.parity_shard_count);
+            SmallVec::with_capacity(number_missing_data);
 
-        for i_slice in invalid_indices
-            .iter()
-            .cloned()
-            .take_while(|i| i < &data_shard_count)
-        {
-            matrix_rows.push(data_decode_matrix.get_row(i_slice));
+        if single_missing_data {
+            matrix_rows.push(
+                self.single_data_decode_rows
+                    .get_row(invalid_indices[0]),
+            );
+        } else if let Some(data_decode_matrix) = data_decode_matrix.as_ref() {
+            for &i_slice in &invalid_indices[..number_missing_data] {
+                matrix_rows.push(data_decode_matrix.get_row(i_slice));
+            }
         }
 
         self.code_some_slices(&matrix_rows, &sub_shards, &mut missing_data_slices);
 
-        if data_only {
+        if data_only || missing_parity_slices.is_empty() {
             Ok(())
         } else {
             // Now that we have all of the data shards intact, we can
@@ -870,15 +1007,10 @@ impl<F: Field> ReedSolomon<F> {
             // any that we just calculated.  The output is whichever of the
             // parity shards were missing.
             let mut matrix_rows: SmallVec<[&[F::Elem]; 32]> =
-                SmallVec::with_capacity(self.parity_shard_count);
-            let parity_rows = self.get_parity_rows();
+                SmallVec::with_capacity(number_missing_parity);
 
-            for i_slice in invalid_indices
-                .iter()
-                .cloned()
-                .skip_while(|i| i < &data_shard_count)
-            {
-                matrix_rows.push(parity_rows[i_slice - data_shard_count]);
+            for &i_slice in &invalid_indices[number_missing_data..] {
+                matrix_rows.push(self.matrix.get_row(i_slice));
             }
             {
                 // Gather up all the data shards.
@@ -902,11 +1034,7 @@ impl<F: Field> ReedSolomon<F> {
                     next_maybe_good = up_to + 1;
                 };
 
-                for i_slice in invalid_indices
-                    .iter()
-                    .cloned()
-                    .take_while(|i| i < &data_shard_count)
-                {
+                for &i_slice in &invalid_indices[..number_missing_data] {
                     push_good_up_to(&mut all_data_slices, i_slice);
                     all_data_slices.push(missing_data_slices[i_new_data_slice]);
                     i_new_data_slice += 1;

--- a/src/core.rs
+++ b/src/core.rs
@@ -482,8 +482,7 @@ impl<F: Field> ReedSolomon<F> {
         let total_shards = data_shards + parity_shards;
 
         let matrix = Self::build_matrix(data_shards, total_shards);
-        let single_data_decode_rows =
-            Self::build_single_data_decode_rows(&matrix, data_shards);
+        let single_data_decode_rows = Self::build_single_data_decode_rows(&matrix, data_shards);
 
         Ok(ReedSolomon {
             data_shard_count: data_shards,
@@ -985,10 +984,7 @@ impl<F: Field> ReedSolomon<F> {
             SmallVec::with_capacity(number_missing_data);
 
         if single_missing_data {
-            matrix_rows.push(
-                self.single_data_decode_rows
-                    .get_row(invalid_indices[0]),
-            );
+            matrix_rows.push(self.single_data_decode_rows.get_row(invalid_indices[0]));
         } else if let Some(data_decode_matrix) = data_decode_matrix.as_ref() {
             for &i_slice in &invalid_indices[..number_missing_data] {
                 matrix_rows.push(data_decode_matrix.get_row(i_slice));

--- a/src/galois_8.rs
+++ b/src/galois_8.rs
@@ -45,6 +45,21 @@ impl crate::Field for Field {
     fn mul_slice_add(c: u8, input: &[u8], out: &mut [u8]) {
         mul_slice_xor(c, input, out)
     }
+
+    #[cfg(all(
+        feature = "simd-accel",
+        any(target_arch = "x86_64", target_arch = "aarch64"),
+        not(target_env = "msvc"),
+        not(any(target_os = "android", target_os = "ios"))
+    ))]
+    #[inline]
+    fn mul_slices<T: AsRef<[u8]>, U: AsMut<[u8]>>(
+        matrix_rows: &[&[u8]],
+        inputs: &[T],
+        outputs: &mut [U],
+    ) {
+        mul_slices(matrix_rows, inputs, outputs)
+    }
 }
 
 /// Type alias of ReedSolomon over GF(2^8).
@@ -280,6 +295,114 @@ extern "C" {
         out: *mut u8,
         len: libc::size_t,
     ) -> libc::size_t;
+
+    fn reedsolomon_gal_mul_matrix(
+        inputs: *const *const u8,
+        coefficient_rows: *const *const u8,
+        low_tables: *const u8,
+        high_tables: *const u8,
+        input_count: libc::size_t,
+        outputs: *const *mut u8,
+        output_count: libc::size_t,
+        len: libc::size_t,
+    ) -> libc::size_t;
+}
+
+#[cfg(all(
+    feature = "simd-accel",
+    any(target_arch = "x86_64", target_arch = "aarch64"),
+    not(target_env = "msvc"),
+    not(any(target_os = "android", target_os = "ios"))
+))]
+#[inline]
+fn mul_slices<T: AsRef<[u8]>, U: AsMut<[u8]>>(
+    matrix_rows: &[&[u8]],
+    inputs: &[T],
+    outputs: &mut [U],
+) {
+    assert_eq!(matrix_rows.len(), outputs.len());
+    assert!(inputs.len() <= 256);
+    assert!(outputs.len() <= 256);
+
+    if outputs.is_empty() {
+        return;
+    }
+
+    if inputs.is_empty() {
+        for row in matrix_rows {
+            assert_eq!(row.len(), 0);
+        }
+        return;
+    }
+
+    let output_len = outputs[0].as_mut().len();
+    for input in inputs {
+        assert_eq!(input.as_ref().len(), output_len);
+    }
+    for row in matrix_rows {
+        assert_eq!(row.len(), inputs.len());
+    }
+    for output in outputs.iter_mut() {
+        assert_eq!(output.as_mut().len(), output_len);
+    }
+
+    if output_len == 0 {
+        return;
+    }
+
+    if outputs.len() == 1 {
+        let output = outputs[0].as_mut();
+
+        for (i, (elem, input)) in matrix_rows[0].iter().zip(inputs).enumerate() {
+            if i == 0 {
+                mul_slice(*elem, input.as_ref(), output);
+            } else {
+                mul_slice_xor(*elem, input.as_ref(), output);
+            }
+        }
+        return;
+    }
+
+    let mut input_ptrs = [::core::mem::MaybeUninit::<*const u8>::uninit(); 256];
+    let mut coefficient_ptrs = [::core::mem::MaybeUninit::<*const u8>::uninit(); 256];
+    let mut output_ptrs = [::core::mem::MaybeUninit::<*mut u8>::uninit(); 256];
+
+    for (ptr, input) in input_ptrs.iter_mut().zip(inputs) {
+        let input = input.as_ref();
+        ptr.write(input.as_ptr());
+    }
+    for (ptr, row) in coefficient_ptrs.iter_mut().zip(matrix_rows) {
+        ptr.write(row.as_ptr());
+    }
+    for (ptr, output) in output_ptrs.iter_mut().zip(outputs.iter_mut()) {
+        let output = output.as_mut();
+        ptr.write(output.as_mut_ptr());
+    }
+
+    let bytes_done = unsafe {
+        reedsolomon_gal_mul_matrix(
+            input_ptrs.as_ptr() as *const *const u8,
+            coefficient_ptrs.as_ptr() as *const *const u8,
+            MUL_TABLE_LOW.as_ptr() as *const u8,
+            MUL_TABLE_HIGH.as_ptr() as *const u8,
+            inputs.len(),
+            output_ptrs.as_ptr() as *const *mut u8,
+            outputs.len(),
+            output_len,
+        ) as usize
+    };
+
+    for (row, output) in matrix_rows.iter().zip(outputs) {
+        let output = output.as_mut();
+        for (i, (elem, input)) in row.iter().zip(inputs).enumerate() {
+            let input = input.as_ref();
+            if i == 0 {
+                mul_slice_pure_rust(*elem, &input[bytes_done..], &mut output[bytes_done..]);
+            } else {
+                mul_slice_xor_pure_rust(*elem, &input[bytes_done..], &mut output[bytes_done..]);
+            }
+        }
+    }
 }
 
 #[cfg(all(
@@ -331,6 +454,13 @@ mod tests {
     extern crate alloc;
 
     use alloc::vec;
+    #[cfg(all(
+        feature = "simd-accel",
+        any(target_arch = "x86_64", target_arch = "aarch64"),
+        not(target_env = "msvc"),
+        not(any(target_os = "android", target_os = "ios"))
+    ))]
+    use alloc::vec::Vec;
 
     use super::*;
     use crate::tests::fill_random;
@@ -615,6 +745,69 @@ mod tests {
                 mul_slice_xor(c, &input, &mut output_copy);
 
                 assert_eq!(output, output_copy);
+            }
+        }
+    }
+
+    #[cfg(all(
+        feature = "simd-accel",
+        any(target_arch = "x86_64", target_arch = "aarch64"),
+        not(target_env = "msvc"),
+        not(any(target_os = "android", target_os = "ios"))
+    ))]
+    #[test]
+    fn test_simd_matrix_kernel_boundaries() {
+        const LENGTHS: &[usize] = &[
+            0, 1, 15, 16, 17, 31, 32, 33, 63, 64, 65, 95, 96, 97, 127, 128, 129, 191, 192, 193,
+            255, 256, 257, 1_024, 2_047, 2_048, 2_049, 10_003,
+        ];
+
+        for &len in LENGTHS {
+            for &input_count in &[0, 1, 2, 3, 4, 7, 8, 16] {
+                let inputs: Vec<Vec<u8>> = (0..input_count)
+                    .map(|input| {
+                        (0..len)
+                            .map(|offset| offset.wrapping_mul(17).wrapping_add(input * 29) as u8)
+                            .collect()
+                    })
+                    .collect();
+
+                for output_count in 0..=9 {
+                    let rows: Vec<Vec<u8>> = (0..output_count)
+                        .map(|output| {
+                            (0..input_count)
+                                .map(|input| {
+                                    if output == 0 {
+                                        [0, 1, 255][input % 3]
+                                    } else if output == 1 {
+                                        1
+                                    } else {
+                                        (output * 47 + input * 31 + 1) as u8
+                                    }
+                                })
+                                .collect()
+                        })
+                        .collect();
+                    let row_refs: Vec<&[u8]> = rows.iter().map(Vec::as_slice).collect();
+                    let initial_output = if input_count == 0 { 0 } else { 0xA5 };
+                    let mut actual = vec![vec![initial_output; len]; output_count];
+                    let mut expected = vec![vec![0; len]; output_count];
+
+                    for output in 0..output_count {
+                        for offset in 0..len {
+                            expected[output][offset] = (0..input_count).fold(0, |sum, input| {
+                                sum ^ mul(rows[output][input], inputs[input][offset])
+                            });
+                        }
+                    }
+
+                    mul_slices(&row_refs, &inputs, &mut actual);
+                    assert_eq!(
+                        actual, expected,
+                        "len={}, inputs={}, outputs={}",
+                        len, input_count, output_count
+                    );
+                }
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,28 @@ pub trait Field: Sized {
             *o = Self::add(o.clone(), Self::mul(elem.clone(), i.clone()))
         }
     }
+
+    /// Apply several matrix rows to the same set of input slices.
+    fn mul_slices<T: AsRef<[Self::Elem]>, U: AsMut<[Self::Elem]>>(
+        matrix_rows: &[&[Self::Elem]],
+        inputs: &[T],
+        outputs: &mut [U],
+    ) {
+        assert_eq!(matrix_rows.len(), outputs.len());
+
+        for (matrix_row, output) in matrix_rows.iter().zip(outputs) {
+            assert_eq!(matrix_row.len(), inputs.len());
+            let output = output.as_mut();
+
+            for (i, (elem, input)) in matrix_row.iter().zip(inputs).enumerate() {
+                if i == 0 {
+                    Self::mul_slice(*elem, input.as_ref(), output);
+                } else {
+                    Self::mul_slice_add(*elem, input.as_ref(), output);
+                }
+            }
+        }
+    }
 }
 
 /// Something which might hold a shard.


### PR DESCRIPTION
Makes AVX2 path ~50% faster for encode and reconstruct.

Makes AVX512 path 30-60% faster(depending on parameters) for encode and does not improve reconstruction(regression in reconstruct one but 30% improvement in reconstruct all).

Created using GPT-Sol 5.6-high with `/goal`.

Draft until correctness can be verified.